### PR TITLE
Add dynamic var for JSON date format

### DIFF
--- a/src/compojure/api/json.clj
+++ b/src/compojure/api/json.clj
@@ -6,6 +6,11 @@
             [clojure.walk :as walk]
             [clojure.java.io :as io]))
 
+;; JSON standard date format according to
+;; http://stackoverflow.com/questions/10286204/the-right-json-date-format
+(def ^{:dynamic true} *json-date-format* "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+
+
 (defn json-request?
   "Checks from request content-type weather it's JSON."
   [{:keys [content-type] :as request}]
@@ -38,7 +43,7 @@
       (if (coll? body)
         (-> response
           (content-type "application/json; charset=utf-8")
-          (update-in [:body] cheshire/generate-string))
+          (update-in [:body] cheshire/generate-string {:date-format *json-date-format*}))
         response))))
 
 (defn json-support


### PR DESCRIPTION
Hello, dear Metosin,

Thank you for your wonderful library, it really helps me in my dealing with swagger-enabled APIs!
But there is one little issue that I'm having with date formats. It seems that `cheshire.core/generate-string` by default uses the format `"yyyy-MM-dd'T'HH:mm:ss'Z'"`, while officially it should be `"yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"`, according to this:
http://stackoverflow.com/questions/10286204/the-right-json-date-format.
So I made a small change to your code to make it possible for the user to change the date format to whatever he likes, while having the default one according to the standard.
