### PR TITLE
Add support for regular expression matching in URL parameters

### DIFF
--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -73,9 +73,14 @@
     (s/split #" ")
     (->> (map #(if (.startsWith % ":") (keyword (.substring % 1)) %)))))
 
+(defn remove-param-regexes [p]
+  (if (vector? p)
+    (first p)
+    p))
+
 (defn create-api-route [[ks v]]
   [{:method (first (keep second ks))
-    :uri (->> ks (map first) s/join create-uri)} v])
+    :uri (->> ks (map first) (map remove-param-regexes) s/join create-uri)} v])
 
 (defn extract-method [body]
   (-> body first str .toLowerCase keyword))

--- a/test/compojure/api/swagger_test.clj
+++ b/test/compojure/api/swagger_test.clj
@@ -69,7 +69,12 @@
          more-routes*)) => [{:method :get
                             :uri ["/api/true"]}
                            {:method :get
-                            :uri ["/api/more/even"]}]))
+                            :uri ["/api/more/even"]}])
+
+  (fact "Parameter regular expressions are discarded"
+    (extract-routes '(context "/api" []
+                       (GET ["/:param" :param #"[a-z]+"] [] identity))) => [{:method :get
+                                                                           :uri ["/api/" :param]}]))
 
 (fact "path-to-index"
   (path-to-index "/")    => "/index.html"


### PR DESCRIPTION
Compojure routing supports [regular expression matching in URL parameters](https://github.com/weavejester/compojure/wiki/Routes-In-Detail). The same syntax works fine with compojure-api's `GET*` etc, since it passes the path parameter to Compojure's routing macros. Swagger parsing however fails and produces mangled URLs. For example,

``` clj
(context "/api" []
  (GET* ["/item/:name" :name #"[a-z/]+"] [name] identity))
```

results in a path of `/api["/item/{name":name#"[a-z]+"]}` instead of `/api/item/{name}`. This PR adds support for the regex path syntax to compojure.api.swagger.
