### PR TITLE
Support running inside an application server.

### DIFF
--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -121,7 +121,12 @@
     (map attach-meta-data-to-route)
     reverse))
 
-(defn path-to-index [path] (s/replace (str path "/index.html") #"//" "/"))
+(defn path-to-index [req path]
+  (let [servlet-context (:servlet-context req)
+        context (if servlet-context
+                  (.getContextPath servlet-context)
+                  "")]
+    (s/replace (str context path "/index.html") #"//" "/")))
 
 (defn swagger-info [body]
   (let [[parameters body] (extract-parameters body)
@@ -138,7 +143,7 @@
   ([] (swagger-ui "/"))
   ([path]
     (routes
-      (GET path [] (redirect (path-to-index path)))
+      (GET path req (redirect (path-to-index req path)))
       (route/resources path {:root "swagger-ui"}))))
 
 (defn swagger-docs

--- a/test/compojure/api/swagger_test.clj
+++ b/test/compojure/api/swagger_test.clj
@@ -91,9 +91,9 @@
                                   :model {:param String}}]}}]))
 
 (fact "path-to-index"
-  (path-to-index "/")    => "/index.html"
-  (path-to-index "/ui")  => "/ui/index.html"
-  (path-to-index "/ui/") => "/ui/index.html")
+  (path-to-index {} "/")    => "/index.html"
+  (path-to-index {} "/ui")  => "/ui/index.html"
+  (path-to-index {} "/ui/") => "/ui/index.html")
 
 (facts "swagger-info"
 


### PR DESCRIPTION
This PR makes redirect to swagger's index.html to work when running inside application server.
