### PR TITLE
exclude plumbing.core/update

### DIFF
--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -2,7 +2,7 @@
   (:require [compojure.api.common :refer :all]
             [compojure.core :refer [routes]]
             [ring.util.http-response :refer [internal-server-error]]
-            [plumbing.core :refer :all]
+            [plumbing.core :refer :all :exclude [update]]
             [plumbing.fnk.impl :as fnk-impl]
             [ring.swagger.schema :as schema]
             [ring.swagger.common :refer :all]


### PR DESCRIPTION
it's not used, and it clobbers clojure.core/update, causing warns under Clojure 1.7

(I created this pull request once before but it was buggy, I fixed the bug and force pushed, but apparently that was against policy, so, new pull request, sorry for the confusion)
