### PR TITLE
Add restructure-param :headers option

### DIFF
--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -121,6 +121,16 @@
       (update-in [:parameters :parameters] conj {:type :query
                                                  :model model})))
 
+; reads header-params into a enchanced let. First parameter is the let symbol,
+; second is the Model to coerced! against.
+; Examples:
+; :headers [headers Headers]
+(defmethod restructure-param :headers [_ [value model] acc]
+  (-> acc
+      (update-in [:lets] into [value (src-coerce! model :headers :query)])
+      (update-in [:parameters :parameters] conj {:type :header
+                                                 :model model})))
+
 ; restructures body-params with plumbing letk notation. Example:
 ; :body-params [id :- Long name :- String]
 (defmethod restructure-param :body-params [_ body-params acc]


### PR DESCRIPTION
Hi,

I found that we wanted to put a number of common headers in one defschema, but a :headers option similar to :body was missing.  We added this to one of our internal projects, so I thought I'd submit it back upstream to you.   Let me know if this looks good or you have comments.

Thanks