### PR TITLE
wrap context* routes in compojure.core/routes instead of do

### DIFF
--- a/src/compojure/api/core.clj
+++ b/src/compojure/api/core.clj
@@ -44,4 +44,4 @@
 (defmacro OPTIONS* [& args] (restructure #'OPTIONS args))
 (defmacro POST*    [& args] (restructure #'POST    args))
 (defmacro PUT*     [& args] (restructure #'PUT     args))
-(defmacro context* [& args] (restructure #'context args))
+(defmacro context* [& args] (restructure #'context args :body-wrap 'compojure.core/routes))

--- a/src/compojure/api/core.clj
+++ b/src/compojure/api/core.clj
@@ -44,4 +44,4 @@
 (defmacro OPTIONS* [& args] (restructure #'OPTIONS args))
 (defmacro POST*    [& args] (restructure #'POST    args))
 (defmacro PUT*     [& args] (restructure #'PUT     args))
-(defmacro context* [& args] (restructure #'context args :body-wrap 'compojure.core/routes))
+(defmacro context* [& args] (restructure #'context args {:body-wrap 'compojure.core/routes}))

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -253,8 +253,9 @@
             (RuntimeException.
               (str "unknown compojure destruction syntax: " arg)))))
 
-(defn restructure [method [path arg & args] & {:keys [body-wrap] :or {body-wrap 'do}}]
-  (let [method-symbol (symbol (str (-> method meta :ns) "/" (-> method meta :name)))
+(defn restructure [method [path arg & args] & [{:keys [body-wrap]}]]
+  (let [body-wrap (or body-wrap 'do)
+        method-symbol (symbol (str (-> method meta :ns) "/" (-> method meta :name)))
         [parameters body] (extract-parameters args)
         [lets letks responses middlewares] [[] [] nil nil]
         [lets arg-with-request arg] (destructure-compojure-api-request lets arg)

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -253,7 +253,7 @@
             (RuntimeException.
               (str "unknown compojure destruction syntax: " arg)))))
 
-(defn restructure [method [path arg & args]]
+(defn restructure [method [path arg & args] & {:keys [body-wrap] :or {body-wrap 'do}}]
   (let [method-symbol (symbol (str (-> method meta :ns) "/" (-> method meta :name)))
         [parameters body] (extract-parameters args)
         [lets letks responses middlewares] [[] [] nil nil]
@@ -271,7 +271,7 @@
           (map-of lets letks responses middlewares parameters body)
           parameters)
 
-        body `(do ~@body)
+        body `(~body-wrap ~@body)
         body (if (seq letks) `(letk ~letks ~body) body)
         body (if (seq lets) `(let ~lets ~body) body)
         body (if (seq middlewares) `(route-middlewares ~middlewares ~body ~arg) body)

--- a/test/compojure/api/core_integration_test.clj
+++ b/test/compojure/api/core_integration_test.clj
@@ -682,3 +682,20 @@
                                         s/Keyword s/Any}}
                    :summary "jeah"
                    :tags #{:ipa}}))))
+
+(fact "multiple routes in context*"
+  (let [metas (atom nil)]
+    (defapi api
+      (swaggered +name+
+        (context* "/foo" []
+          (GET* "/bar" [] (ok ["bar"]))
+          (GET* "/baz" [] (ok ["baz"])))))
+
+    (fact "first route works"
+      (let [[status body] (get* api "/foo/bar")]
+        status => 200
+        body => ["bar"]))
+    (fact "second route works"
+      (let [[status body] (get* api "/foo/baz")]
+        status => 200
+        body => ["baz"]))))


### PR DESCRIPTION
See https://github.com/metosin/compojure-api/issues/79 for original issue.

This commit wraps `context*` routes in `compojure.core/routes` instead of `do`. Previously, the `do` form was only returning the last route in the `context*`, instead of all routes. See the [new test](https://github.com/metosin/compojure-api/pull/80/files#diff-2ef72077fcceeec886a02410dbc2d583R685) in `core_integration_tests.clj`.