### PR TITLE
Invalid doc with multiple identical route with context star

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ refers to it directly, you need remove the direct reference.
 
 ```clojure
 [prismatic/plumbing "0.4.2"] is available but we use "0.4.1"
+[prismatic/schema "0.4.1"] is available but we use "0.4.0"
 [potemkin "0.3.13"] is available but we use "0.3.12"
 [compojure "1.3.3"] is available but we use "1.3.2"
 [metosin/ring-swagger "0.19.4"] is available but we use "0.19.3"

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
                  [potemkin "0.3.13"]
                  [cheshire "5.4.0"]
                  [compojure "1.3.3"]
-                 [prismatic/schema "0.4.0"]
+                 [prismatic/schema "0.4.1"]
                  [org.tobereplaced/lettercase "1.0.0"]
                  [metosin/ring-http-response "0.6.1"]
                  [metosin/ring-swagger "0.20.0"]

--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -22,10 +22,10 @@
 ;;
 
 ; TODO: #'wrap-routes
-(def compojure-route?     #{#'GET #'POST #'PUT #'DELETE #'HEAD #'OPTIONS #'PATCH #'ANY})
-(def compojure-context?   #{#'context})
+(def compojure-route? #{#'GET #'POST #'PUT #'DELETE #'HEAD #'OPTIONS #'PATCH #'ANY})
+(def compojure-context? #{#'context})
 (def compojure-letroutes? #{#'let-routes})
-(def compojure-macro?     (union compojure-route? compojure-context? compojure-letroutes?))
+(def compojure-macro? (union compojure-route? compojure-context? compojure-letroutes?))
 
 (defn inline? [x] (and (symbol? x) (-> x eval-re-resolve value-of meta :inline)))
 
@@ -33,17 +33,17 @@
   (walk/prewalk
     (fn [x]
       (cond
-        (inline? x) (-> x value-of meta :source) ;; resolve the syms!
-        (seq? x)    (let [sym (first x)]
-                      (if (and
-                            (symbol? sym)
-                            (or
-                              (compojure-macro? (eval-re-resolve sym))
-                              (m/meta-container? (eval-re-resolve sym))))
-                        (filter (comp not nil?) x)
-                        (let [result (macroexpand-1 x)]
-                          ;; stop if macro expands to itself
-                          (if (= result x) result (list result)))))
+        (inline? x) (-> x value-of meta :source)            ;; resolve the syms!
+        (seq? x) (let [sym (first x)]
+                   (if (and
+                         (symbol? sym)
+                         (or
+                           (compojure-macro? (eval-re-resolve sym))
+                           (m/meta-container? (eval-re-resolve sym))))
+                     (filter (comp not nil?) x)
+                     (let [result (macroexpand-1 x)]
+                       ;; stop if macro expands to itself
+                       (if (= result x) result (list result)))))
         :else x))
     form))
 
@@ -58,10 +58,10 @@
   (when-let [meta (m/unwrap-meta-container container)]
     (let [meta (update-in meta [:return] eval)
           meta (reduce
-                (fn [acc x]
-                  (update-in acc [:parameters x] eval))
-                meta
-                (-> meta :parameters keys))
+                 (fn [acc x]
+                   (update-in acc [:parameters x] eval))
+                 meta
+                 (-> meta :parameters keys))
           meta (update-in meta [:responses] eval)]
       (remove-empty-keys meta))))
 
@@ -105,10 +105,10 @@
           (let [[m p] x
                 rm (and (symbol? m) (eval-re-resolve m))]
             (cond
-              (compojure-route? rm)     (->CompojureRoute p {} x)
-              (compojure-context? rm)   (->CompojureRoutes p (context-metadata x) (filter-routes x))
+              (compojure-route? rm) (->CompojureRoute p {} x)
+              (compojure-context? rm) (->CompojureRoutes p (context-metadata x) (filter-routes x))
               (compojure-letroutes? rm) (->CompojureRoutes "" (context-metadata x) (filter-routes x))
-              :else                     x)))
+              :else x)))
         x))
     form))
 
@@ -129,14 +129,17 @@
     (is-a? CompojureRoute r)
     [[p (extract-method b)]
      [:endpoint {:meta (merge-meta m (:m r))
-                                        :body (rest b)}]]
+                 :body (rest b)}]]
 
     (is-a? CompojureRoutes r)
     [[p nil] (->> c
                   (map (partial create-paths (merge-meta m (:m r))))
                   (reduce (fn [acc [k v]]
-                            (assoc-map-ordered acc k (if (get acc k) (merge (get acc k) v) v)))
-                          {}))]))
+                            (assoc-map-ordered acc k (if (get acc k)
+                                                       ;; match first compojure route
+                                                       (deep-merge v (get acc k))
+                                                       v)))
+                          (array-map)))]))
 
 ;;
 ;; ensure path parameters
@@ -230,7 +233,7 @@
 
 (defn swagger-info [body]
   (let [[parameters body] (extract-parameters body)
-        routes  (extract-routes body)
+        routes (extract-routes body)
         details (assoc parameters :paths routes)]
     [details body]))
 
@@ -268,8 +271,8 @@
                    (st/select-keys [:info s/Keyword])
                    (st/assoc (s/optional-key :tags)
                              [{:name (s/either s/Str s/Keyword)
-                                                      (s/optional-key :description) s/Str
-                                                      ss/X- s/Any}]))]
+                               (s/optional-key :description) s/Str
+                               ss/X- s/Any}]))]
     (st/select-schema Schema info)))
 
 (defmacro swagger-docs
@@ -304,7 +307,7 @@
          (let [produces# (-> request# :meta :produces (or []))
                consumes# (-> request# :meta :consumes (or []))
                runtime-info# {:produces produces#
-                            :consumes consumes#}]
+                              :consumes consumes#}]
            (ok
              (let [swagger# (merge runtime-info#
                                    ~extra-info

--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -12,9 +12,8 @@
             [ring.swagger.swagger2-schema :as ss]
             [potemkin :refer [import-vars]]
             [ring.swagger.common :refer :all]
-            [ring.swagger.schema :as rss]
             [ring.swagger.core :as swagger]
-            [ring.swagger.ui :as ui]
+            [ring.swagger.ui]
             [ring.swagger.swagger2 :as swagger2]
             [schema.core :as s]))
 
@@ -128,7 +127,8 @@
   (cond
 
     (is-a? CompojureRoute r)
-    [[p (extract-method b)] [:endpoint {:meta (merge-meta m (:m r))
+    [[p (extract-method b)]
+     [:endpoint {:meta (merge-meta m (:m r))
                                         :body (rest b)}]]
 
     (is-a? CompojureRoutes r)
@@ -161,7 +161,9 @@
 (defn ensure-path-parameters [uri route-with-meta]
   (if (seq (path-params uri))
     (update-in route-with-meta [:metadata :parameters :path]
-               #(dissoc (merge (string-path-parameters uri) (remove-keyword-namespaces %)) s/Keyword))
+               #(dissoc (merge (string-path-parameters uri)
+                               (remove-keyword-namespaces %))
+                        s/Keyword))
     route-with-meta))
 
 ;;
@@ -264,7 +266,8 @@
                info)
         Schema (-> ss/Swagger
                    (st/select-keys [:info s/Keyword])
-                   (st/assoc (s/optional-key :tags) [{:name (s/either s/Str s/Keyword)
+                   (st/assoc (s/optional-key :tags)
+                             [{:name (s/either s/Str s/Keyword)
                                                       (s/optional-key :description) s/Str
                                                       ss/X- s/Any}]))]
     (st/select-schema Schema info)))

--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -22,10 +22,10 @@
 ;;
 
 ; TODO: #'wrap-routes
-(def compojure-route? #{#'GET #'POST #'PUT #'DELETE #'HEAD #'OPTIONS #'PATCH #'ANY})
-(def compojure-context? #{#'context})
+(def compojure-route?     #{#'GET #'POST #'PUT #'DELETE #'HEAD #'OPTIONS #'PATCH #'ANY})
+(def compojure-context?   #{#'context})
 (def compojure-letroutes? #{#'let-routes})
-(def compojure-macro? (union compojure-route? compojure-context? compojure-letroutes?))
+(def compojure-macro?     (union compojure-route? compojure-context? compojure-letroutes?))
 
 (defn inline? [x] (and (symbol? x) (-> x eval-re-resolve value-of meta :inline)))
 
@@ -33,17 +33,17 @@
   (walk/prewalk
     (fn [x]
       (cond
-        (inline? x) (-> x value-of meta :source)            ;; resolve the syms!
-        (seq? x) (let [sym (first x)]
-                   (if (and
-                         (symbol? sym)
-                         (or
-                           (compojure-macro? (eval-re-resolve sym))
-                           (m/meta-container? (eval-re-resolve sym))))
-                     (filter (comp not nil?) x)
-                     (let [result (macroexpand-1 x)]
-                       ;; stop if macro expands to itself
-                       (if (= result x) result (list result)))))
+        (inline? x) (-> x value-of meta :source) ;; resolve the syms!
+        (seq? x)    (let [sym (first x)]
+                      (if (and
+                            (symbol? sym)
+                            (or
+                              (compojure-macro? (eval-re-resolve sym))
+                              (m/meta-container? (eval-re-resolve sym))))
+                        (filter (comp not nil?) x)
+                        (let [result (macroexpand-1 x)]
+                          ;; stop if macro expands to itself
+                          (if (= result x) result (list result)))))
         :else x))
     form))
 
@@ -105,10 +105,10 @@
           (let [[m p] x
                 rm (and (symbol? m) (eval-re-resolve m))]
             (cond
-              (compojure-route? rm) (->CompojureRoute p {} x)
-              (compojure-context? rm) (->CompojureRoutes p (context-metadata x) (filter-routes x))
+              (compojure-route? rm)     (->CompojureRoute p {} x)
+              (compojure-context? rm)   (->CompojureRoutes p (context-metadata x) (filter-routes x))
               (compojure-letroutes? rm) (->CompojureRoutes "" (context-metadata x) (filter-routes x))
-              :else x)))
+              :else                     x)))
         x))
     form))
 


### PR DESCRIPTION
Respect the Vanilla Compojure route matching: if there are several swagger routes with identical path & method, take only the first. Cleanup.

Fixes #89 