### PR TITLE
Defroutes* is accessed over a Var for better development productivity.

### DIFF
--- a/test/compojure/api/sweet_test.clj
+++ b/test/compojure/api/sweet_test.clj
@@ -33,7 +33,8 @@
                       :url "http://www.eclipse.org/legal/epl-v10.html"}}})
   ping-routes
   (context "/api" []
-    ping-routes
+    ;; defroutes* over a Var
+    #'ping-routes
     (GET* "/bands" []
       :return   [Band]
       :summary  "Gets all Bands"


### PR DESCRIPTION
Fixes #91.