### PR TITLE
add consumes and produces keys, at http verb level

### DIFF
--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -116,6 +116,11 @@
 (defmethod restructure-param :operationId [k v acc]
   (update-in acc [:parameters] assoc k v))
 
+(defmethod restructure-param :consumes [k v acc]
+  (update-in acc [:parameters] assoc k v))
+
+(defmethod restructure-param :produces [k v acc]
+  (update-in acc [:parameters] assoc k v))
 ;;
 ;; Smart restructurings
 ;;


### PR DESCRIPTION
it's now possible to have different consumes/produces pr. route instead
only on api/context.

I'm currently working on extending compojure-api to work with Liberator.
When using liberator and compojure, your nomally define one route per liberator resource with the ANY macro, and the liberator key  :allowed-methods  [:get :put] restricts the http verbs. 

My current approach is a macro with the following parameters [path params liberator-resource swagger]
and compiles a GET* PUT* POST* based on the :allowed-methods in the liberator resource 
And then inject the right swagger keys into each form (eg. :body for PUT, POST, PATCH) and :produces  :consumes (not for GET) based on the liberator key :available-media-types. 

What I need to do right now is move the parsing* and schema validation of the request body from middleware into the :malformed? and again liberator should also validate the response body. 

Liberator should handle encoding and decoding of request/response body according to the :available-media-types. 

Do you have any suggestion on how to bypass the compojure-api middleware in the defapi and whats the best way of injecting schema validation based on status code into liberator's :malformed? and schema validation for the body ?  

Cheers 
Thomas 



