### PR TITLE
Set :consumes in :form-params and :multipart-params

### DIFF
--- a/examples/src/examples/thingie.clj
+++ b/examples/src/examples/thingie.clj
@@ -190,5 +190,4 @@
     (POST* "/upload" []
       :multipart-params [file :- TempFileUpload]
       :middlewares [wrap-multipart-params]
-      :consumes ["multipart/form-data"]
       (ok (dissoc file :tempfile)))))

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -212,13 +212,15 @@
   (let [schema (strict (fnk-schema form-params))]
     (-> acc
         (update-in [:letks] into [form-params (src-coerce! schema :form-params :query)])
-        (update-in [:parameters :parameters :formData] st/merge schema))))
+        (update-in [:parameters :parameters :formData] st/merge schema)
+        (assoc-in [:parameters :consumes] ["application/x-www-form-urlencoded"]))))
 
 (defmethod restructure-param :multipart-params [_ params acc]
   (let [schema (strict (fnk-schema params))]
     (-> acc
         (update-in [:letks] into [params (src-coerce! schema :multipart-params :query)])
-        (update-in [:parameters :parameters :formData] st/merge schema))))
+        (update-in [:parameters :parameters :formData] st/merge schema)
+        (assoc-in [:parameters :consumes] ["multipart/form-data"]))))
 
 ; restructures header-params with plumbing letk notation. Example:
 ; :header-params [id :- Long name :- String]

--- a/test/compojure/api/sweet_test.clj
+++ b/test/compojure/api/sweet_test.clj
@@ -96,7 +96,8 @@
                                                          s/Keyword s/Any}}}}
                 "/api/header" {:get {:parameters {:header {:hp Boolean
                                                            s/Keyword s/Any}}}}
-                "/api/form" {:post {:parameters {:formData {:fp Boolean}}}}
+                "/api/form" {:post {:parameters {:formData {:fp Boolean}}
+                                    :consumes ["application/x-www-form-urlencoded"]}}
                 "/api/primitive" {:get {:responses {200 {:schema String
                                                          :description ""}}}}
                 "/api/primitiveArray" {:get {:responses {200 {:schema [String]
@@ -166,7 +167,8 @@
                                                                      :description ""
                                                                      :required true
                                                                      :type "boolean"}]
-                                                        :responses {:default {:description ""}}}}
+                                                        :responses {:default {:description ""}}
+                                                        :consumes ["application/x-www-form-urlencoded"]}}
                          (keyword "/api/ping") {:get {:responses {:default {:description ""}}}}
                          (keyword "/api/primitive") {:get {:responses {:200 {:description ""
                                                                              :schema {:type "string"}}}}}


### PR DESCRIPTION
:form-params or :multipart-params are probably never used together with other content-types so this should make sense?