### PR TITLE
Coercion matchers rethought

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@
         (ok (->NonSwaggerRecord "ping"))))))
 
 ; clojure.lang.Compiler$CompilerException: java.lang.IllegalArgumentException:
-; don't know how to create json-type of: class compojure.api.core_integration_test.NonSwaggerRecord
+; don't know how to create json-type of: class compojure.api.integration_test.NonSwaggerRecord
 ```
 
 * updated dependencies:

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ To ensure that your API is valid, one can call `compojure.api.swagger/validate`.
         (ok (->NonSwaggerRecord "ping"))))))
 
 ; clojure.lang.Compiler$CompilerException: java.lang.IllegalArgumentException:
-; don't know how to create json-type of: class compojure.api.core_integration_test.NonSwaggerRecord
+; don't know how to create json-type of: class compojure.api.integration_test.NonSwaggerRecord
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -432,7 +432,7 @@ There are three types of coercion:
 
 Default implementation uses Ring-swagger coercion matchers, `json-schema-coercion-matcher` for `:body` and `:response`
 and `query-schema-coercion-matcher` for `:string`. One can override the defaults using an api-middleware option
-`:coercion` or using a restructuring key `:coerction`. Both expect a function value of type
+`:coercion` or using a restructuring key `:coercion`. Both expect a function value of type
 `ring-request->coercion-type->coercion-matcher`. This allows one to select the coercion matcher
 based on request parameters such as used transport, expected return format etc. See [the tests](https://github.com/metosin/compojure-api/blob/91428f6cdc1872cb23eb5429ed915b7cc1ecc739/test/compojure/api/core_integration_test.clj#L1074-L1180)
 for examples how to change the coercion.

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Default implementation uses Ring-swagger coercion matchers, `json-schema-coercio
 and `query-schema-coercion-matcher` for `:string`. One can override the defaults using an api-middleware option
 `:coercion` or using a restructuring key `:coercion`. Both expect a function value of type
 `ring-request->coercion-type->coercion-matcher`. This allows one to select the coercion matcher
-based on request parameters such as used transport, expected return format etc. See [the tests](https://github.com/metosin/compojure-api/blob/91428f6cdc1872cb23eb5429ed915b7cc1ecc739/test/compojure/api/core_integration_test.clj#L1074-L1180)
+based on request parameters such as used transport, expected return format etc. See [the tests](./test/compojure/api/coercion_test.clj)
 for examples how to change the coercion.
 
 All coercion code uses the `ring.swagger.schema/coerce!` internally, which throws managed exceptions when a value

--- a/README.md
+++ b/README.md
@@ -434,7 +434,8 @@ Default implementation uses Ring-swagger coercion matchers, `json-schema-coercio
 and `query-schema-coercion-matcher` for `:string`. One can override the defaults using an api-middleware option
 `:coercion` or using a restructuring key `:coerction`. Both expect a function value of type
 `ring-request->coercion-type->coercion-matcher`. This allows one to select the coercion matcher
-based on request parameters such as used transport, expected return format etc.
+based on request parameters such as used transport, expected return format etc. See [the tests](https://github.com/metosin/compojure-api/blob/91428f6cdc1872cb23eb5429ed915b7cc1ecc739/test/compojure/api/core_integration_test.clj#L1074-L1180)
+for examples how to change the coercion.
 
 All coercion code uses the `ring.swagger.schema/coerce!` internally, which throws managed exceptions when a value
 can't be coerced. The `api-middleware` catches these exceptions and returns the validation error as serializable

--- a/README.md
+++ b/README.md
@@ -415,20 +415,32 @@ the `:components` restucturing with letk-syntax:
 
 To see this in action, try `lein run` and navigate to Components api group.
 
-## Models
+## Schemas
 
-Compojure-api uses the [Schema](https://github.com/Prismatic/schema)-based modeling,
-backed up by [ring-swagger](https://github.com/metosin/ring-swagger) for mapping the models int Swagger/JSON Schemas.
-**Note**: for Map-based schemas, Keyword keys should be used instead of Strings.
+Compojure-api uses the [Schema](https://github.com/Prismatic/schema) to describe data models, backed up by
+[ring-swagger](https://github.com/metosin/ring-swagger) for mapping the models int Swagger JSON Schemas.
+With Map-based schemas, Keyword keys should be used instead of Strings.
 
-Two coercers are available (and automatically selected with smart destructuring): 
-one for json and another for string-based formats (query-parameters & path-parameters). 
-See [Ring-Swagger](https://github.com/metosin/ring-swagger#schema-coersion) for more details.
+### Coercion
 
-### sample schema and coercion
+Input and output schemas are coerced automatically using a schema coercion matcher selected by a coercion type.
+There are three types of coercion:
 
-Compojure-api selects the right coercer and does the coercion behalf of the user, but if one
-wan't to call the coersion manually, here's a sample:
+- `:body`  coercion of the request body
+- `:string` coercion of query, path, header and form parameters
+- `:response` coercsion of response body
+
+Default implementation uses Ring-swagger coercion matchers, `json-schema-coercion-matcher` for `:body` and `:response`
+and `query-schema-coercion-matcher` for `:string`. One can override the defaults using an api-middleware option
+`:coercion` or using a restructuring key `:coerction`. Both expect a function value of type
+`ring-request->coercion-type->coercion-matcher`. This allows one to select the coercion matcher
+based on request parameters such as used transport, expected return format etc.
+
+All coercion code uses the `ring.swagger.schema/coerce!` internally, which throws managed exceptions when a value
+can't be coerced. The `api-middleware` catches these exceptions and returns the validation error as serializable
+Clojure data structure, sent to the client.
+
+One can also call `ring.swagger.schema/coerce!` manually:
 
 ```clojure
 (require '[ring.swagger.schema :refer [coerce!])
@@ -443,9 +455,6 @@ wan't to call the coersion manually, here's a sample:
 (coerce! Thingie {:id 123, :tags "kakka"})
 ; => ExceptionInfo throw+: {:type :ring.swagger.schema/validation, :error {:tags disallowed-key, :tag missing-required-key}}  ring.swagger.schema/coerce! (schema.clj:88)
 ```
-
-The thrown exception by `coerce!` is caught by the `api-middleware` and the results are returned to the
-api user in decent format (overridable, of course).
 
 ## Models, routes and meta-data
 

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -1,7 +1,7 @@
 (ns compojure.api.meta
   (:require [clojure.walk :refer [keywordize-keys]]
             [compojure.api.common :refer :all]
-            [compojure.api.middleware :refer [get-components]]
+            [compojure.api.middleware :as mw]
             [compojure.core :refer [routes]]
             [plumbing.core :refer :all]
             [plumbing.fnk.impl :as fnk-impl]
@@ -254,7 +254,7 @@
 
 ; Bind to stuff in request components using letk syntax
 (defmethod restructure-param :components [_ components acc]
-  (update-in acc [:letks] into [components `(get-components ~+compojure-api-request+)]))
+  (update-in acc [:letks] into [components `(mw/get-components ~+compojure-api-request+)]))
 
 ;;
 ;; Api

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -257,6 +257,10 @@
 (defmethod restructure-param :components [_ components acc]
   (update-in acc [:letks] into [components `(mw/get-components ~+compojure-api-request+)]))
 
+; route-spesific override for coercers
+(defmethod restructure-param :coercion [_ coercion acc]
+  (update-in acc [:middlewares] conj `(mw/wrap-coercion ~coercion)))
+
 ;;
 ;; Api
 ;;

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -58,11 +58,11 @@
       (if-let [schema (:schema (responses status))]
         (if-let [matcher (:response (mw/get-coercion-matcher-provider request))]
           (let [body (schema/coerce schema (:body response) matcher)]
-          (if (schema/error? body)
-            (internal-server-error {:errors (:error body)})
-            (assoc response
-              ::serializable? true
-              :body body)))
+            (if (schema/error? body)
+              (internal-server-error {:errors (:error body)})
+              (assoc response
+                ::serializable? true
+                :body body)))
           response)
         response))))
 

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -10,7 +10,8 @@
             [ring.swagger.common :refer [deep-merge]]
             [ring.swagger.middleware :as rsm]
             [ring.swagger.coerce :as rsc]
-            [ring.util.http-response :refer :all])
+            [ring.util.http-response :refer :all]
+            [schema.core :as s])
   (:import [com.fasterxml.jackson.core JsonParseException]
            [org.yaml.snakeyaml.parser ParserException]))
 
@@ -90,9 +91,11 @@
 ;; coercion
 ;;
 
+(s/defschema CoercionType (s/enum :body :string :response))
+
 (def default-coercion-matchers
-  {:json rsc/json-schema-coercion-matcher
-   :query rsc/query-schema-coercion-matcher
+  {:body rsc/json-schema-coercion-matcher
+   :string rsc/query-schema-coercion-matcher
    :response rsc/json-schema-coercion-matcher})
 
 (def no-response-coercion

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -162,23 +162,31 @@
   "Opinionated chain of middlewares for web apis. Takes options-map, with namespaces
    options for the used middlewares (see middlewares for full details on options):
 
-   - **:exceptions**           for *compojure.api.middleware/wrap-exceptions*
-       - **:exception-handler**  function to handle uncaught exceptions
-   - **:validation-errors**    for *ring.swagger.middleware/wrap-validation-errors*
-       - **:error-handler**      function to handle ring-swagger schema exceptions
-       - **:catch-core-errors?** whether to catch also `:schema.core/errors`
-   - **:format**               for ring-middleware-format middlewares
-       - **:formats**            sequence of supported formats, e.g. `[:json-kw :edn]`
-       - **:param-opts**         for *ring.middleware.format-params/wrap-restful-params*,
-                                 e.g. `{:transit-json {:options {:handlers readers}}}`
-       - **:response-opts**      for *ring.middleware.format-params/wrap-restful-response*,
-                                 e.g. `{:transit-json {:handlers writers}}`
-   - **:ring-swagger**         options for ring-swagger's swagger-json method.
-                               e.g. `{:ignore-missing-mappings? true}`
-   - **:components**           Components which should be accessible to handlers using
-                               :components restructuring. (If you are using defapi,
-                               you might want to take look at using wrap-components
-                               middleware manually.)"
+   - **:exceptions**                for *compojure.api.middleware/wrap-exceptions*
+       - **:exception-handler**       function to handle uncaught exceptions
+
+   - **:validation-errors**         for *ring.swagger.middleware/wrap-validation-errors*
+       - **:error-handler**           function to handle ring-swagger schema exceptions
+       - **:catch-core-errors?**      whether to catch also `:schema.core/errors`
+
+   - **:format**                    for ring-middleware-format middlewares
+       - **:formats**                 sequence of supported formats, e.g. `[:json-kw :edn]`
+       - **:param-opts**              for *ring.middleware.format-params/wrap-restful-params*,
+                                      e.g. `{:transit-json {:options {:handlers readers}}}`
+       - **:response-opts**           for *ring.middleware.format-params/wrap-restful-response*,
+                                      e.g. `{:transit-json {:handlers writers}}`
+
+   - **:ring-swagger**              options for ring-swagger's swagger-json method.
+                                    e.g. `{:ignore-missing-mappings? true}`
+
+   - **:coercion-matcher-provider** A function from request->type->coercion-matcher, used
+                                    in enpoint coersion for :json, :query and :response.
+                                    Defaults to `compojure.api.middleware/default-coercion-matchers`
+
+   - **:components**                Components which should be accessible to handlers using
+                                    :components restructuring. (If you are using defapi,
+                                    you might want to take look at using wrap-components
+                                    middleware manually.)"
   [handler & [options]]
   (let [options (deep-merge api-middleware-defaults options)
         {:keys [exceptions validation-erros format components]} options

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -103,6 +103,10 @@
                      (fn [_] default-coercion-matchers))]
     (provider request)))
 
+(defn wrap-coercion [handler coercion]
+  (fn [request]
+    (handler (assoc-in request [::options :coercion] coercion))))
+
 ;;
 ;; ring-middleware-format stuff
 ;;

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -87,7 +87,7 @@
   (::options request))
 
 ;;
-;; coercion-matcher-provider
+;; coercion
 ;;
 
 (def default-coercion-matchers
@@ -99,7 +99,7 @@
   (dissoc default-coercion-matchers :response))
 
 (defn get-coercion-matcher-provider [request]
-  (let [provider (or (:coercion-matcher-provider (get-options request))
+  (let [provider (or (:coercion (get-options request))
                      (fn [_] default-coercion-matchers))]
     (provider request)))
 
@@ -179,7 +179,7 @@
    - **:ring-swagger**              options for ring-swagger's swagger-json method.
                                     e.g. `{:ignore-missing-mappings? true}`
 
-   - **:coercion-matcher-provider** A function from request->type->coercion-matcher, used
+   - **:coercion**                  A function from request->type->coercion-matcher, used
                                     in enpoint coersion for :json, :query and :response.
                                     Defaults to `compojure.api.middleware/default-coercion-matchers`
 
@@ -198,7 +198,7 @@
         (wrap-exceptions exceptions)
         (rsm/wrap-swagger-data {:produces (->mime-types (remove response-only-mimes formats))
                                 :consumes (->mime-types formats)})
-        (wrap-options (select-keys options [:ring-swagger :coercion-matcher-provider]))
+        (wrap-options (select-keys options [:ring-swagger :coercion]))
         (wrap-restful-params
          (merge {:formats (remove response-only-mimes formats)
                  :handle-error handle-req-error}

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -163,12 +163,13 @@
                                middleware manually.)"
   [handler & [options]]
   (let [options (deep-merge api-middleware-defaults options)
-        {{:keys [formats params-opts response-opts]} :format :keys [components]} options]
+        {:keys [exceptions validation-erros format components]} options
+        {:keys [formats params-opts response-opts]} format]
     (-> handler
         (cond-> components (wrap-components components))
         ring.middleware.http-response/wrap-http-response
-        (rsm/wrap-validation-errors (:validation-errors options))
-        (wrap-exceptions (:exceptions options))
+        (rsm/wrap-validation-errors validation-erros)
+        (wrap-exceptions exceptions)
         (rsm/wrap-swagger-data {:produces (->mime-types (remove response-only-mimes formats))
                                 :consumes (->mime-types formats)})
         (wrap-options (select-keys options [:ring-swagger]))

--- a/test/compojure/api/coercion_test.clj
+++ b/test/compojure/api/coercion_test.clj
@@ -1,0 +1,115 @@
+(ns compojure.api.coercion-test
+  (:require [compojure.api.sweet :refer :all]
+            [compojure.api.test-utils :refer :all]
+            [midje.sweet :refer :all]
+            [ring.util.http-response :refer :all]
+            [schema.core :as s]
+            [compojure.api.middleware :as mw]))
+
+(fact "custom coercion"
+
+  (fact "response coercion"
+    (let [ping-route (GET* "/ping" []
+                       :return {:pong s/Str}
+                       (ok {:pong 123}))]
+
+      (fact "by default, applies response coercion"
+        (let [app (api
+                    ping-route)]
+          (let [[status body] (get* app "/ping")]
+            status => 500
+            body => (contains {:errors irrelevant}))))
+
+      (fact "response-coersion can ba disabled"
+        (let [app (api
+                    {:coercion mw/no-response-coercion}
+                    ping-route)]
+          (let [[status body] (get* app "/ping")]
+            status => 200
+            body => {:pong 123})))))
+
+  (fact "body coersion"
+    (let [beer-route (POST* "/beer" []
+                       :body [body {:beers #{(s/enum "ipa" "apa")}}]
+                       (ok body))]
+
+      (fact "by default, applies body coercion (to set)"
+        (let [app (api
+                    beer-route)]
+          (let [[status body] (post* app "/beer" (json {:beers ["ipa" "apa" "ipa"]}))]
+            status => 200
+            body => {:beers ["ipa" "apa"]})))
+
+      (fact "body-coersion can ba disabled"
+        (let [no-body-coercion (fn [_] (dissoc mw/default-coercion-matchers :body))
+              app (api
+                    {:coercion no-body-coercion}
+                    beer-route)]
+          (let [[status body] (post* app "/beer" (json {:beers ["ipa" "apa" "ipa"]}))]
+            status => 200
+            body => {:beers ["ipa" "apa" "ipa"]})))
+
+      (fact "body-coersion can ba changed"
+        (let [nop-body-coercion (fn [_] (assoc mw/default-coercion-matchers :body (constantly nil)))
+              app (api
+                    {:coercion nop-body-coercion}
+                    beer-route)]
+          (let [[status body] (post* app "/beer" (json {:beers ["ipa" "apa" "ipa"]}))]
+            status => 400
+            body => (contains {:errors irrelevant}))))))
+
+  (fact "query coersion"
+    (let [query-route (GET* "/query" []
+                        :query-params [i :- s/Int]
+                        (ok {:i i}))]
+
+      (fact "by default, applies query coercion (string->int)"
+        (let [app (api
+                    query-route)]
+          (let [[status body] (get* app "/query" {:i 10})]
+            status => 200
+            body => {:i 10})))
+
+      (fact "query-coersion can ba disabled"
+        (let [no-query-coercion (fn [_] (dissoc mw/default-coercion-matchers :string))
+              app (api
+                    {:coercion no-query-coercion}
+                    query-route)]
+          (let [[status body] (get* app "/query" {:i 10})]
+            status => 200
+            body => {:i "10"})))
+
+      (fact "query-coersion can ba changed"
+        (let [nop-query-coercion (fn [_] (assoc mw/default-coercion-matchers :string (constantly nil)))
+              app (api
+                    {:coercion nop-query-coercion}
+                    query-route)]
+          (let [[status body] (get* app "/query" {:i 10})]
+            status => 400
+            body => (contains {:errors irrelevant}))))))
+
+  (fact "route-spesific coercion"
+    (let [app (api
+                (GET* "/default" []
+                  :query-params [i :- s/Int]
+                  (ok {:i i}))
+                (GET* "/disabled-coercion" []
+                  :coercion (fn [_] (assoc mw/default-coercion-matchers :string (constantly nil)))
+                  :query-params [i :- s/Int]
+                  (ok {:i i}))
+                (GET* "/no-coercion" []
+                  :coercion (constantly nil)
+                  :query-params [i :- s/Int]
+                  (ok {:i i})))]
+      (fact "default coercion"
+        (let [[status body] (get* app "/default" {:i 10})]
+          status => 200
+          body => {:i 10}))
+      (fact "disabled coercion"
+        (let [[status body] (get* app "/disabled-coercion" {:i 10})]
+          status => 400
+          body => (contains {:errors irrelevant})))
+      (fact "no coercion"
+        (let [[status body] (get* app "/no-coercion" {:i 10})]
+          status => 200
+          body => {:i "10"})))))

--- a/test/compojure/api/core_integration_test.clj
+++ b/test/compojure/api/core_integration_test.clj
@@ -1,9 +1,7 @@
 (ns compojure.api.core-integration-test
-  (:require [cheshire.core :as cheshire]
-            [compojure.api.sweet :refer :all]
+  (:require [compojure.api.sweet :refer :all]
             [compojure.api.test-utils :refer :all]
             [midje.sweet :refer :all]
-            [peridot.core :as p]
             [flatland.ordered.map :as om]
             [ring.util.http-response :refer :all]
             [schema.core :as s]
@@ -11,58 +9,6 @@
             [compojure.api.swagger :as caw]
             [ring.util.http-status :as status]
             [compojure.api.middleware :as mw]))
-
-;;
-;; common
-;;
-
-(defn json [x] (cheshire/generate-string x))
-
-(defn follow-redirect [state]
-  (if (some-> state :response :headers (get "Location"))
-    (p/follow-redirect state)
-    state))
-
-(defn raw-get* [app uri & [params headers]]
-  (let [{{:keys [status body headers]} :response}
-        (-> (p/session app)
-            (p/request uri
-                       :request-method :get
-                       :params (or params {})
-                       :headers (or headers {}))
-            follow-redirect)]
-    [status (read-body body) headers]))
-
-(defn get* [app uri & [params headers]]
-  (let [[status body headers]
-        (raw-get* app uri params headers)]
-    [status (parse-body body) headers]))
-
-(defn form-post* [app uri params]
-  (let [{{:keys [status body]} :response}
-        (-> (p/session app)
-            (p/request uri
-                       :request-method :post
-                       :params params))]
-    [status (parse-body body)]))
-
-(defn raw-post* [app uri & [data content-type headers]]
-  (let [{{:keys [status body]} :response}
-        (-> (p/session app)
-            (p/request uri
-                       :request-method :post
-                       :headers (or headers {})
-                       :content-type (or content-type "application/json")
-                       :body (.getBytes data)))]
-    [status (read-body body)]))
-
-(defn post* [app uri & [data]]
-  (let [[status body] (raw-post* app uri data)]
-    [status (parse-body body)]))
-
-(defn headers-post* [app uri headers]
-  (let [[status body] (raw-post* app uri "" nil headers)]
-    [status (parse-body body)]))
 
 ;;
 ;; Data

--- a/test/compojure/api/core_integration_test.clj
+++ b/test/compojure/api/core_integration_test.clj
@@ -1087,7 +1087,7 @@
 
       (fact "response-coersion can ba disabled"
         (let [app (api
-                    {:coercion-matcher-provider mw/no-response-coercion}
+                    {:coercion mw/no-response-coercion}
                     ping-route)]
           (let [[status body] (get* app "/ping")]
             status => 200
@@ -1108,7 +1108,7 @@
       (fact "body-coersion can ba disabled"
         (let [no-body-coercion (fn [_] (dissoc mw/default-coercion-matchers :json))
               app (api
-                    {:coercion-matcher-provider no-body-coercion}
+                    {:coercion no-body-coercion}
                     beer-route)]
           (let [[status body] (post* app "/beer" (json {:beers ["ipa" "apa" "ipa"]}))]
             status => 200
@@ -1117,7 +1117,7 @@
       (fact "body-coersion can ba changed"
         (let [nop-body-coercion (fn [_] (assoc mw/default-coercion-matchers :json (constantly nil)))
               app (api
-                    {:coercion-matcher-provider nop-body-coercion}
+                    {:coercion nop-body-coercion}
                     beer-route)]
           (let [[status body] (post* app "/beer" (json {:beers ["ipa" "apa" "ipa"]}))]
             status => 400
@@ -1138,7 +1138,7 @@
       (fact "query-coersion can ba disabled"
         (let [no-query-coercion (fn [_] (dissoc mw/default-coercion-matchers :query))
               app (api
-                    {:coercion-matcher-provider no-query-coercion}
+                    {:coercion no-query-coercion}
                     query-route)]
           (let [[status body] (get* app "/query" {:i 10})]
             status => 200
@@ -1147,7 +1147,7 @@
       (fact "query-coersion can ba changed"
         (let [nop-query-coercion (fn [_] (assoc mw/default-coercion-matchers :query (constantly nil)))
               app (api
-                    {:coercion-matcher-provider nop-query-coercion}
+                    {:coercion nop-query-coercion}
                     query-route)]
           (let [[status body] (get* app "/query" {:i 10})]
             status => 400

--- a/test/compojure/api/core_integration_test.clj
+++ b/test/compojure/api/core_integration_test.clj
@@ -1071,7 +1071,7 @@
         status => 200
         body => {:magic 42}))))
 
-(fact "custom coercion-matcher-provider"
+(fact "custom coercion"
 
   (fact "response coercion"
     (let [ping-route (GET* "/ping" []

--- a/test/compojure/api/core_integration_test.clj
+++ b/test/compojure/api/core_integration_test.clj
@@ -1106,7 +1106,7 @@
             body => {:beers ["ipa" "apa"]})))
 
       (fact "body-coersion can ba disabled"
-        (let [no-body-coercion (fn [_] (dissoc mw/default-coercion-matchers :json))
+        (let [no-body-coercion (fn [_] (dissoc mw/default-coercion-matchers :body))
               app (api
                     {:coercion no-body-coercion}
                     beer-route)]
@@ -1115,7 +1115,7 @@
             body => {:beers ["ipa" "apa" "ipa"]})))
 
       (fact "body-coersion can ba changed"
-        (let [nop-body-coercion (fn [_] (assoc mw/default-coercion-matchers :json (constantly nil)))
+        (let [nop-body-coercion (fn [_] (assoc mw/default-coercion-matchers :body (constantly nil)))
               app (api
                     {:coercion nop-body-coercion}
                     beer-route)]
@@ -1136,7 +1136,7 @@
             body => {:i 10})))
 
       (fact "query-coersion can ba disabled"
-        (let [no-query-coercion (fn [_] (dissoc mw/default-coercion-matchers :query))
+        (let [no-query-coercion (fn [_] (dissoc mw/default-coercion-matchers :string))
               app (api
                     {:coercion no-query-coercion}
                     query-route)]
@@ -1145,7 +1145,7 @@
             body => {:i "10"})))
 
       (fact "query-coersion can ba changed"
-        (let [nop-query-coercion (fn [_] (assoc mw/default-coercion-matchers :query (constantly nil)))
+        (let [nop-query-coercion (fn [_] (assoc mw/default-coercion-matchers :string (constantly nil)))
               app (api
                     {:coercion nop-query-coercion}
                     query-route)]
@@ -1159,7 +1159,7 @@
                   :query-params [i :- s/Int]
                   (ok {:i i}))
                 (GET* "/disabled-coercion" []
-                  :coercion (fn [_] (assoc mw/default-coercion-matchers :query (constantly nil)))
+                  :coercion (fn [_] (assoc mw/default-coercion-matchers :string (constantly nil)))
                   :query-params [i :- s/Int]
                   (ok {:i i}))
                 (GET* "/no-coercion" []

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -1,4 +1,4 @@
-(ns compojure.api.core-integration-test
+(ns compojure.api.integration-test
   (:require [compojure.api.sweet :refer :all]
             [compojure.api.test-utils :refer :all]
             [midje.sweet :refer :all]

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -972,7 +972,7 @@
         (caw/validate app)
         => (throws
              IllegalArgumentException
-             "don't know how to create json-type of: class compojure.api.core_integration_test.NonSwaggerRecord"))))
+             "don't know how to create json-type of: class compojure.api.integration_test.NonSwaggerRecord"))))
 
   (fact "a pre-validated swagger api with invalid swagger records"
     (let [app' `(caw/validate
@@ -986,7 +986,7 @@
         (eval app')
         => (throws
              IllegalArgumentException
-             "don't know how to create json-type of: class compojure.api.core_integration_test.NonSwaggerRecord"))))
+             "don't know how to create json-type of: class compojure.api.integration_test.NonSwaggerRecord"))))
 
   (fact "a non-swagger api with invalid swagger records"
     (let [app (api

--- a/test/compojure/api/meta_test.clj
+++ b/test/compojure/api/meta_test.clj
@@ -9,3 +9,8 @@
     (unwrap-meta-container '(meta-container :abba identity)) => (throws AssertionError))
   (fact "unwrapping non-meta-container returns empty map"
     (unwrap-meta-container 'identity) => {}))
+
+(fact "src-coerce! with deprecated types"
+  (src-coerce! nil nil :query) => (throws AssertionError)
+  (src-coerce! nil nil :json) => (throws AssertionError))
+

--- a/test/compojure/api/test_utils.clj
+++ b/test/compojure/api/test_utils.clj
@@ -1,6 +1,7 @@
 (ns compojure.api.test-utils
   (:require [cheshire.core :as cheshire]
-            [clojure.string :as str])
+            [clojure.string :as str]
+            [peridot.core :as p])
   (:import [java.io InputStream]))
 
 (defn read-body [body]
@@ -22,3 +23,58 @@
   (let [schema-name (keyword (extract-schema-name ref))]
     (get-in spec [:definitions schema-name])))
 
+;;
+;; integration tests
+;;
+
+;;
+;; common
+;;
+
+(defn json [x] (cheshire/generate-string x))
+
+(defn follow-redirect [state]
+  (if (some-> state :response :headers (get "Location"))
+    (p/follow-redirect state)
+    state))
+
+(defn raw-get* [app uri & [params headers]]
+  (let [{{:keys [status body headers]} :response}
+        (-> (p/session app)
+            (p/request uri
+                       :request-method :get
+                       :params (or params {})
+                       :headers (or headers {}))
+            follow-redirect)]
+    [status (read-body body) headers]))
+
+(defn get* [app uri & [params headers]]
+  (let [[status body headers]
+        (raw-get* app uri params headers)]
+    [status (parse-body body) headers]))
+
+(defn form-post* [app uri params]
+  (let [{{:keys [status body]} :response}
+        (-> (p/session app)
+            (p/request uri
+                       :request-method :post
+                       :params params))]
+    [status (parse-body body)]))
+
+(defn raw-post* [app uri & [data content-type headers]]
+  (let [{{:keys [status body]} :response}
+        (-> (p/session app)
+            (p/request uri
+                       :request-method :post
+                       :headers (or headers {})
+                       :content-type (or content-type "application/json")
+                       :body (.getBytes data)))]
+    [status (read-body body)]))
+
+(defn post* [app uri & [data]]
+  (let [[status body] (raw-post* app uri data)]
+    [status (parse-body body)]))
+
+(defn headers-post* [app uri headers]
+  (let [[status body] (raw-post* app uri "" nil headers)]
+    [status (parse-body body)]))


### PR DESCRIPTION
Instead of using statically selected `:json` or `:query` coercion, one can now customize the coercion process either with api-level option or route-level restructuring. Value for both is a function of type `ring-request->coercion-type->coercion-matcher`. 