### PR TITLE
Fix typo in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ from 1.2 to 2.0. See [Migration guide](https://github.com/metosin/compojure-api/
   (swagger-docs 
     {:info {:title "Sample api"}})
     
-  (GET* "/"
+  (GET* "/" []
     :no-doc true
     (ok "hello world"))
 


### PR DESCRIPTION
When trying to use the example I would run into this error: `unknown compojure destruction syntax: :no-doc`
After adding `[]` to the `"/"` route, it solved this issue.