### PR TITLE
Alternative error handler that receives request map as well

### DIFF
--- a/test/compojure/api/middleware_test.clj
+++ b/test/compojure/api/middleware_test.clj
@@ -43,6 +43,8 @@
 
     (fact "error-handler can be overridden"
       ((wrap-exceptions failure {:exception-handler (constantly (ok "FAIL"))}) request)
-      => (ok "FAIL"))))
-
-
+      => (ok "FAIL"))
+    
+    (fact "rich-handler gets request map as well"
+      ((wrap-exceptions failure {:rich-handler (fn [e req] (ok (:foo req)))}) {:foo "bar"})
+      => (ok "bar"))))


### PR DESCRIPTION
The best place for sending errors to e.g. Bugsnag is a custom error handler. In addition to exception details, it is sometimes useful to share data about the request itself (e.g. the logged in user).

This change introduces the possibility to use an alternative kind of handler function, one that receives the request map as well, while keeping backward compatibility.

This could have been achieved by arity testing. This (among with other possibilities) could be discussed here.