### PR TITLE
expose some origin compojure core func

### DIFF
--- a/src/compojure/api/sweet.clj
+++ b/src/compojure/api/sweet.clj
@@ -12,9 +12,18 @@
    let-request
    routing
    routes
+   defroutes
    context
    let-routes
-   wrap-routes]
+   wrap-routes
+   GET
+   POST
+   PATCH
+   DELETE
+   PUT
+   OPTIONS
+   ANY
+   HEAD]
 
   ;; with enchanced methods
   [compojure.api.core


### PR DESCRIPTION
because for some project they are deeply bundled with the origin compojure project and compojure-api.sweet has some conflict with compojure.core so i think it's a good idea to expose some core method from compojure.core so others can migrate from compojure to compojure-api smoothly and enjoy the powerful swagger-ui