### PR TITLE
Allow api users to also define own handler for response validation errors

### DIFF
--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -9,6 +9,7 @@
             [ring.swagger.schema :as schema]
             [ring.swagger.json-schema :as js]
             [ring.util.http-response :refer [internal-server-error]]
+            [slingshot.slingshot :refer [throw+]]
             [schema.core :as s]
             [schema-tools.core :as st]))
 
@@ -59,7 +60,7 @@
         (if-let [matcher (:response (mw/get-coercion-matcher-provider request))]
           (let [body (schema/coerce schema (:body response) matcher)]
             (if (schema/error? body)
-              (internal-server-error {:errors (:error body)})
+              (throw+ (assoc body :type ::response-validation))
               (assoc response
                 ::serializable? true
                 :body body)))

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -220,8 +220,7 @@
     (fact "Invalid json in body causes 400 with error message in json"
       (let [[status body] (post* app "/models/user" "{INVALID}")]
         status => 400
-        (:type body) => "json-parse-exception"
-        (:message body) => truthy))))
+        (:errors body) => contains "Unexpected character"))))
 
 (fact ":responses"
   (fact "normal cases"
@@ -906,10 +905,15 @@
         status => 200
         body => 1))
 
-    (fact "return case, invalid request"
+    (fact "return case, not schema valid request"
       (let [[status body] (post* app "/get-long" "{\"x\": \"1\"}")]
         status => 400
         body => (contains {:custom-error "/get-long"})))
+
+    (fact "return case, invalid json request"
+          (let [[status body] (post* app "/get-long" "{x: 1}")]
+            status => 400
+            body => (contains {:custom-error "/get-long"})))
 
     (fact "return case, valid request & invalid model"
       (let [[status body] (post* app "/get-long" "{\"x\": 2}")]

--- a/test/compojure/api/middleware_test.clj
+++ b/test/compojure/api/middleware_test.clj
@@ -31,18 +31,16 @@
         success (fn [_] (ok "SUCCESS"))
         request irrelevant]
 
-    (fact "passed through normal requests"
-      ((wrap-exceptions success {:exception-handler (constantly (ok "FAIL"))}) request)
+    (fact "passed through normal requests with deprecated exception-handler"
+      ((wrap-exceptions success (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))})) request)
       => success)
 
     (fact "converts exceptions into safe internal server errors"
-      ((wrap-exceptions failure) request)
+      ((wrap-exceptions failure (:exceptions api-middleware-defaults)) request)
       => (contains {:status status/internal-server-error
                     :body (contains {:class exception-class
                                      :type "unknown-exception"})}))
 
-    (fact "error-handler can be overridden"
-      ((wrap-exceptions failure {:exception-handler (constantly (ok "FAIL"))}) request)
+    (fact "deprecated exception-handler still works"
+      ((wrap-exceptions failure (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))})) request)
       => (ok "FAIL"))))
-
-

--- a/test/compojure/api/middleware_test.clj
+++ b/test/compojure/api/middleware_test.clj
@@ -32,15 +32,15 @@
         request irrelevant]
 
     (fact "passed through normal requests with deprecated exception-handler"
-      ((wrap-exceptions success (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))})) request)
+      ((wrap-exceptions success (support-deprecated-error-handler-config (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))}))) request)
       => success)
 
     (fact "converts exceptions into safe internal server errors"
-      ((wrap-exceptions failure (:exceptions api-middleware-defaults)) request)
+      ((wrap-exceptions failure (:error-handlers (:exceptions api-middleware-defaults))) request)
       => (contains {:status status/internal-server-error
                     :body (contains {:class exception-class
                                      :type "unknown-exception"})}))
 
     (fact "deprecated exception-handler still works"
-      ((wrap-exceptions failure (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))})) request)
+      ((wrap-exceptions failure (support-deprecated-error-handler-config (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))}))) request)
       => (ok "FAIL"))))


### PR DESCRIPTION
We want to handle also response validation errors self,
so that we can log and notice invalid server data also from server logs in production and development.
