### PR TITLE
Exception refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
   * **BREAKING**: new signature for dispatching custom JSON Schema transformations, old signature will break (nicely at compile-time), see [Readme](https://github.com/metosin/ring-swagger/blob/master/README.md) for details.
   * **BREAKING**: File support moved to ring-swagger. Use `ring.swagger.upload` instead of `compojure.api.upload`.
   * Support for collections in query parameters. E.g. `:query-params [x :- [Long]]` & url `?x=1&x=2&x=3` should result in `x` being `[1 2 3]`.
-* move `context` from `compojure.api.sweet` to `compojure.api.legacy`. Use `context*` instead.
-* updated deps:
+* **BREAKING**: `:validation-errors :error-handler`, `:validation-errors :catch-core-errors?`
+  and `:exceptions :exception-handler` options have been removed.
+  * These have been replaced with general `:exceptions :handler` options.
+  * **BREAKING**: New handler use different arity than old handler functions.
+* Move `context` from `compojure.api.sweet` to `compojure.api.legacy`. Use `context*` instead.
+* Updated deps:
 
 ```clojure
 [metosin/ring-swagger "0.21.0-SNAPSHOT"] is available but we use "0.20.4"
@@ -14,7 +18,7 @@
 ## 0.22.2 (12.8.2015)
 
 * fixes [150](https://github.com/metosin/compojure-api/issues/150)
- 
+
 ## 0.22.1 (12.7.2015)
 
 * fixes [137](https://github.com/metosin/compojure-api/issues/137) & [134](https://github.com/metosin/compojure-api/issues/134), thanks to @thomaswhitcomb!
@@ -135,7 +139,7 @@
 
 * response descriptions can be given also with run-time meta-data (`with-meta`), fixes [#96](https://github.com/metosin/compojure-api/issues/96)
   * in next MINOR version, we'll switch to (Ring-)Swagger 2.0 format.
-   
+
 ```clojure
 (context* "/responses" []
   :tags ["responses"]

--- a/src/compojure/api/exception.clj
+++ b/src/compojure/api/exception.clj
@@ -1,0 +1,52 @@
+(ns compojure.api.exception
+  (:require [ring.util.http-response :refer [internal-server-error bad-request]]
+            [clojure.walk :refer [postwalk]]
+            [plumbing.core :refer [for-map]]
+            [schema.utils :as su])
+  (:import [schema.utils ValidationError]))
+
+;;
+;; Default exception handlers
+;;
+
+(defn print-stack-trace-exception-handler
+  "Prints stacktrace to console and returns safe error response.
+
+   Error response only contains class of the Exception so that it won't accidentally
+   expose secret details."
+  [^Exception e error-type request]
+  (.printStackTrace e)
+  (internal-server-error {:type "unknown-exception"
+                          :class (.getName (.getClass e))}))
+
+(defn stringify-schema-error
+  "Stringifies symbols and validation errors in Schema error, keeping the structure intact."
+  [error]
+  (postwalk
+    (fn [x]
+      (if-not (map? x)
+        x
+        (for-map [[k v] x]
+          k (cond
+              (instance? ValidationError v) (str (su/validation-error-explain v))
+              (symbol? v) (str v)
+              :else v))))
+    error))
+
+(defn stringify-error [error]
+  (if (su/error? error)
+    (stringify-schema-error (su/error-val error))
+    (str error)))
+
+(defn internal-server-error-handler [error error-type request]
+  (internal-server-error {:errors (stringify-error error)}))
+
+(defn bad-request-error-handler [error error-type request]
+  (bad-request {:errors (stringify-error error)}))
+
+;;
+;; Mappings from other Exception types to our base types
+;;
+
+(def legacy-exception-types
+  {:ring.swagger.schema/validation ::request-validation})

--- a/src/compojure/api/exception.clj
+++ b/src/compojure/api/exception.clj
@@ -45,6 +45,12 @@
   [_ data request]
   (bad-request {:errors (stringify-error (su/error-val data))}))
 
+(defn schema-error-handler
+  "Creates error response based on Schema error."
+  [ex data request]
+  ; FIXME: Why error is not wrapped to ErrorContainer here?
+  (bad-request {:errors (stringify-error (:error data))}))
+
 (defn request-parsing-handler
   [ex data request]
   (let [cause (.getCause ex)]

--- a/src/compojure/api/exception.clj
+++ b/src/compojure/api/exception.clj
@@ -9,7 +9,7 @@
 ;; Default exception handlers
 ;;
 
-(defn print-stack-trace-exception-handler
+(defn safe-handler
   "Prints stacktrace to console and returns safe error response.
 
    Error response only contains class of the Exception so that it won't accidentally
@@ -19,7 +19,7 @@
   (internal-server-error {:type "unknown-exception"
                           :class (.getName (.getClass e))}))
 
-(defn stringify-schema-error
+(defn stringify-error
   "Stringifies symbols and validation errors in Schema error, keeping the structure intact."
   [error]
   (postwalk
@@ -33,16 +33,15 @@
               :else v))))
     error))
 
-(defn stringify-error [error]
-  (if (su/error? error)
-    (stringify-schema-error (su/error-val error))
-    (str error)))
+(defn response-validation-handler
+  "Creates error response based on Schema error."
+  [error error-type request]
+  (internal-server-error {:errors (stringify-error (su/error-val error))}))
 
-(defn internal-server-error-handler [error error-type request]
-  (internal-server-error {:errors (stringify-error error)}))
-
-(defn bad-request-error-handler [error error-type request]
-  (bad-request {:errors (stringify-error error)}))
+(defn request-validation-handler
+  "Creates error response based on Schema error."
+  [error error-type request]
+  (bad-request {:errors (stringify-error (su/error-val error))}))
 
 ;;
 ;; Mappings from other Exception types to our base types

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -9,6 +9,7 @@
             [ring.swagger.schema :as schema]
             [ring.swagger.json-schema :as js]
             [ring.util.http-response :refer [internal-server-error]]
+            [slingshot.slingshot :refer [throw+]]
             [schema.core :as s]
             [schema-tools.core :as st]))
 
@@ -59,7 +60,7 @@
         (if-let [matcher (:response (mw/get-coercion-matcher-provider request))]
           (let [body (schema/coerce schema (:body response) matcher)]
             (if (schema/error? body)
-              (internal-server-error {:errors (:error body)})
+              (throw+ (assoc body :type ::response-validation))
               (assoc response
                 ::serializable? true
                 :body body)))

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -75,7 +75,10 @@
   (assert (not (#{:query :json} type)) (str type " is DEPRECATED since 0.22.0. Use :body or :string instead."))
   `(let [value# (keywordize-keys (~key ~+compojure-api-request+))]
      (if-let [matcher# (~type (mw/get-coercion-matcher-provider ~+compojure-api-request+))]
-       (schema/coerce! ~schema value# matcher#)
+       (let [result# (schema/coerce ~schema value# matcher#)]
+         (if (schema/error? result#)
+           (throw+ (assoc result# :type ::ex/request-validation))
+           result#))
        value#)))
 
 (defn- convert-return [schema]

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -2,6 +2,7 @@
   (:require [clojure.walk :refer [keywordize-keys]]
             [compojure.api.common :refer :all]
             [compojure.api.middleware :as mw]
+            [compojure.api.exception :as ex]
             [compojure.core :refer [routes]]
             [plumbing.core :refer :all]
             [plumbing.fnk.impl :as fnk-impl]
@@ -60,7 +61,7 @@
         (if-let [matcher (:response (mw/get-coercion-matcher-provider request))]
           (let [body (schema/coerce schema (:body response) matcher)]
             (if (schema/error? body)
-              (throw+ (assoc body :type ::response-validation))
+              (throw+ (assoc body :type ::ex/response-validation))
               (assoc response
                 ::serializable? true
                 :body body)))

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -205,10 +205,15 @@
         {:keys [exceptions format components]} options
         {:keys [formats params-opts response-opts]} format]
     ; Break at compile time if there are deprecated options
-    (assert (not (:error-handler (:validation-errors options))) "Deprecated option: [:validation-errors :error-handler], use [:exceptions :handlers :compojure.api.middleware/request-validation] instead.")
+    (assert (not (:error-handler (:validation-errors options)))
+            (str "Deprecated option: [:validation-errors :error-handler], "
+                 "use {:exceptions {:handlers {:compojure.api.middleware/request-validation your-handler}}} instead."))
     (assert (not (:catch-core-errors? (:validation-errors options)))
-            "Deprecated option: [:validation-errors :catch-core-errors?], use {:exceptions {:handlers {:schema.core/error compojure.api.exception/schema-error-handler}}} instead.")
-    (assert (not (:exception-handler (:exceptions options))) "Deprecated option: [:exceptions :exception-handler], use [:exceptions :handlers :compojure.api.exception/default] instead.")
+            (str "Deprecated option: [:validation-errors :catch-core-errors?], "
+                 "use {:exceptions {:handlers {:schema.core/error compojure.api.exception/schema-error-handler}}} instead."))
+    (assert (not (:exception-handler (:exceptions options)))
+            (str "Deprecated option: [:exceptions :exception-handler], "
+                 "use {:exceptions {:handlers {:compojure.api.exception/default your-handler}}} instead."))
     (-> handler
         (cond-> components (wrap-components components))
         ring.middleware.http-response/wrap-http-response

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -46,7 +46,7 @@
      - **:compojure.api.exception/default** - Handler used when exception type doesn't match other handler,
                                               by default prints stack trace."
   [handler {:keys [error-handlers]}]
-  (let [default-handler (get error-handlers ::ex/default ex/print-stack-trace-exception-handler)]
+  (let [default-handler (get error-handlers ::ex/default ex/safe-handler)]
     (assert (fn? default-handler) "Default exception handler must be a function.")
     (fn [request]
       (try+
@@ -135,7 +135,7 @@
 
 (defn handle-req-error [^Throwable e handler request]
   (if (or (instance? JsonParseException e) (instance? ParserException e))
-    (throw+ {:type ex/+request-validation+} e)
+    (throw+ {:type ::ex/request-validation} e)
     (throw+ e)))
 
 (defn serializable?
@@ -169,9 +169,9 @@
        - **:error-handlers**          map of error handlers for different error types.
                                       An error handler is a function of type specific error object (eg. schema.utils.ErrorContainer or java.lang.Exception), error type and request -> response
                                       Default:
-                                      {:compojure.api.exception/request-validation  compojure.api.exception/bad-request-error-handler
-                                       :compojure.api.exception/response-validation compojure.api.exception/internal-server-error-handler
-                                       :compojure.api.exception/default             compojure.api.exception/print-stack-trace-exception-handler}
+                                      {:compojure.api.exception/request-validation  compojure.api.exception/request-validation-handler
+                                       :compojure.api.exception/response-validation compojure.api.exception/response-validation-handler
+                                       :compojure.api.exception/default             compojure.api.exception/safe-handler}
                                       Note: Adding alias for exception namespace makes it easier to define these options.
 
    - **:format**                    for ring-middleware-format middlewares

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -46,7 +46,7 @@
      - **:compojure.api.exception/default** - Handler used when exception type doesn't match other handler,
                                               by default prints stack trace."
   [handler {:keys [error-handlers]}]
-  (let [default-handler (get error-handlers ex/+default+ ex/print-stack-trace-exception-handler)]
+  (let [default-handler (get error-handlers ::ex/default ex/print-stack-trace-exception-handler)]
     (assert (fn? default-handler) "Default exception handler must be a function.")
     (fn [request]
       (try+
@@ -155,9 +155,9 @@
   {:format {:formats [:json-kw :yaml-kw :edn :transit-json :transit-msgpack]
             :params-opts {}
             :response-opts {}}
-   :exceptions {:error-handlers {::ex/request-validation  ex/bad-request-error-handler
-                                 ::ex/response-validation ex/internal-server-error-handler
-                                 ::ex/default             ex/print-stack-trace-exception-handler}}
+   :exceptions {:error-handlers {::ex/request-validation  ex/request-validation-handler
+                                 ::ex/response-validation ex/response-validation-handler
+                                 ::ex/default             ex/safe-handler}}
    :ring-swagger nil})
 
 ;; TODO: test all options! (https://github.com/metosin/compojure-api/issues/137)

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -170,13 +170,16 @@
    options for the used middlewares (see middlewares for full details on options):
 
    - **:exceptions**                for *compojure.api.middleware/wrap-exceptions*
-       - **:handlers**                map of error handlers for different error types.
-                                      An error handler is a function of type specific error object (eg. schema.utils.ErrorContainer or java.lang.Exception), error type and request -> response
+       - **:handlers**                Map of error handlers for different exception types, type refers to `:type` key in ExceptionInfo data.
+                                      An error handler is a function of exception, ExceptionInfo data and request to response.
                                       Default:
                                       {:compojure.api.exception/request-validation  compojure.api.exception/request-validation-handler
-                                       :compojure.api.exception/request-parsing     compojure.api.exception/
+                                       :compojure.api.exception/request-parsing     compojure.api.exception/request-parsing-handler
                                        :compojure.api.exception/response-validation compojure.api.exception/response-validation-handler
                                        :compojure.api.exception/default             compojure.api.exception/safe-handler}
+
+                                      Note: To catch Schema errors use {:schema.core/error compojure.api.exception/schema-error-handler}
+
                                       Note: Adding alias for exception namespace makes it easier to define these options.
 
    - **:format**                    for ring-middleware-format middlewares
@@ -203,7 +206,8 @@
         {:keys [formats params-opts response-opts]} format]
     ; Break at compile time if there are deprecated options
     (assert (not (:error-handler (:validation-errors options))) "Deprecated option: [:validation-errors :error-handler], use [:exceptions :handlers :compojure.api.middleware/request-validation] instead.")
-    (assert (not (:catch-core-errors? (:validation-errors options))) "Deprecated option: [:validation-errors :catch-core-errors?], use [:exceptions :handlers :compojure.api.exception/request-validation] instead.")
+    (assert (not (:catch-core-errors? (:validation-errors options)))
+            "Deprecated option: [:validation-errors :catch-core-errors?], use {:exceptions {:handlers {:schema.core/error compojure.api.exception/schema-error-handler}}} instead.")
     (assert (not (:exception-handler (:exceptions options))) "Deprecated option: [:exceptions :exception-handler], use [:exceptions :handlers :compojure.api.exception/default] instead.")
     (-> handler
         (cond-> components (wrap-components components))

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -952,8 +952,20 @@
   (api {:validation-errors {:catch-core-errors? true}} nil)
   => (throws AssertionError)
   (api {:exceptions {:exception-handler identity}} nil)
-  => (throws AssertionError)
-  )
+  => (throws AssertionError))
+
+(s/defn schema-error [a :- s/Int]
+  {:bar a})
+
+(fact "handling schema.core/error"
+  (let [app (api
+              {:exceptions {:handlers {:schema.core/error ex/schema-error-handler}}}
+              (GET* "/:a" []
+                :path-params [a :- s/Str]
+                (ok (s/with-fn-validation (schema-error a)))))]
+    (let [[status body] (get* app "/foo")]
+      status => 400
+      body => (contains {:errors vector?}))))
 
 (fact "ring-swagger options"
   (let [app (api

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -220,8 +220,7 @@
     (fact "Invalid json in body causes 400 with error message in json"
       (let [[status body] (post* app "/models/user" "{INVALID}")]
         status => 400
-        (:type body) => "json-parse-exception"
-        (:message body) => truthy))))
+        (:errors body) => contains "Unexpected character"))))
 
 (fact ":responses"
   (fact "normal cases"
@@ -906,10 +905,15 @@
         status => 200
         body => 1))
 
-    (fact "return case, invalid request"
+    (fact "return case, not schema valid request"
       (let [[status body] (post* app "/get-long" "{\"x\": \"1\"}")]
         status => 400
         body => (contains {:custom-error "/get-long"})))
+
+    (fact "return case, invalid json request"
+          (let [[status body] (post* app "/get-long" "{x: 1}")]
+            status => 400
+            body => (contains {:custom-error "/get-long"})))
 
     (fact "return case, valid request & invalid model"
       (let [[status body] (post* app "/get-long" "{\"x\": 2}")]

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -888,9 +888,9 @@
 
 (fact "exceptions options with custom validation error handler"
   (let [app (api
-              {:exceptions {:error-handlers {::ex/request-validation  custom-validation-error-handler
-                                             ::ex/request-parsing     custom-validation-error-handler
-                                             ::ex/response-validation custom-validation-error-handler}}}
+              {:exceptions {:handlers {::ex/request-validation  custom-validation-error-handler
+                                       ::ex/request-parsing     custom-validation-error-handler
+                                       ::ex/response-validation custom-validation-error-handler}}}
               (swagger-docs)
               (POST* "/get-long" []
                     :body   [body {:x Long}]
@@ -921,8 +921,8 @@
 
 (fact "exceptions options with custom exception and error handler"
       (let [app (api
-                  {:exceptions {:error-handlers {::ex/default   custom-exception-handler
-                                                 ::custom-error custom-error-handler}}}
+                  {:exceptions {:handlers {::ex/default   custom-exception-handler
+                                           ::custom-error custom-error-handler}}}
                   (swagger-docs)
                   (GET* "/some-exception" []
                         (throw (new RuntimeException)))

--- a/test/compojure/api/middleware_test.clj
+++ b/test/compojure/api/middleware_test.clj
@@ -31,18 +31,16 @@
         success (fn [_] (ok "SUCCESS"))
         request irrelevant]
 
-    (fact "passed through normal requests"
-      ((wrap-exceptions success {:exception-handler (constantly (ok "FAIL"))}) request)
+    (fact "passed through normal requests with deprecated exception-handler"
+      ((wrap-exceptions success (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))})) request)
       => success)
 
     (fact "converts exceptions into safe internal server errors"
-      ((wrap-exceptions failure) request)
+      ((wrap-exceptions failure (:exceptions api-middleware-defaults)) request)
       => (contains {:status status/internal-server-error
                     :body (contains {:class exception-class
                                      :type "unknown-exception"})}))
 
-    (fact "error-handler can be overridden"
-      ((wrap-exceptions failure {:exception-handler (constantly (ok "FAIL"))}) request)
+    (fact "deprecated exception-handler still works"
+      ((wrap-exceptions failure (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))})) request)
       => (ok "FAIL"))))
-
-

--- a/test/compojure/api/middleware_test.clj
+++ b/test/compojure/api/middleware_test.clj
@@ -31,16 +31,8 @@
         success (fn [_] (ok "SUCCESS"))
         request irrelevant]
 
-    (fact "passed through normal requests with deprecated exception-handler"
-      ((wrap-exceptions success (support-deprecated-error-handler-config (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))}))) request)
-      => success)
-
     (fact "converts exceptions into safe internal server errors"
       ((wrap-exceptions failure (:error-handlers (:exceptions api-middleware-defaults))) request)
       => (contains {:status status/internal-server-error
                     :body (contains {:class exception-class
-                                     :type "unknown-exception"})}))
-
-    (fact "deprecated exception-handler still works"
-      ((wrap-exceptions failure (support-deprecated-error-handler-config (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))}))) request)
-      => (ok "FAIL"))))
+                                     :type "unknown-exception"})}))))

--- a/test/compojure/api/middleware_test.clj
+++ b/test/compojure/api/middleware_test.clj
@@ -32,7 +32,7 @@
         request irrelevant]
 
     (fact "converts exceptions into safe internal server errors"
-      ((wrap-exceptions failure (:error-handlers (:exceptions api-middleware-defaults))) request)
+      ((wrap-exceptions failure (:handlers (:exceptions api-middleware-defaults))) request)
       => (contains {:status status/internal-server-error
                     :body (contains {:class exception-class
                                      :type "unknown-exception"})}))))

--- a/test/compojure/api/middleware_test.clj
+++ b/test/compojure/api/middleware_test.clj
@@ -32,15 +32,15 @@
         request irrelevant]
 
     (fact "passed through normal requests with deprecated exception-handler"
-      ((wrap-exceptions success (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))})) request)
+      ((wrap-exceptions success (support-deprecated-error-handler-config (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))}))) request)
       => success)
 
     (fact "converts exceptions into safe internal server errors"
-      ((wrap-exceptions failure (:exceptions api-middleware-defaults)) request)
+      ((wrap-exceptions failure (:error-handlers (:exceptions api-middleware-defaults))) request)
       => (contains {:status status/internal-server-error
                     :body (contains {:class exception-class
                                      :type "unknown-exception"})}))
 
     (fact "deprecated exception-handler still works"
-      ((wrap-exceptions failure (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))})) request)
+      ((wrap-exceptions failure (support-deprecated-error-handler-config (merge (:exceptions api-middleware-defaults) {:exception-handler (constantly (ok "FAIL"))}))) request)
       => (ok "FAIL"))))


### PR DESCRIPTION
We decided to drop support for old options completely. Options are validated in compile time so there shouldn't be surprising runtime problems.

The default exception handlers are now defined using `compojure.api.exception` namespace instead of `meta` or `middleware`. `coerce!` still throws `:ring.swagger.schema/validation` which we map to our type. This is probably temporary solution as `coerce!` will be moved to another project and when that is done we should probably revisit request validation exception throwing.

Supersedes #158 and #143