### PR TITLE
Clojure.tools.logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 0.24.1-SNAPSHOT
 
-* Fixes [#159](https://github.com/metosin/compojure-api/issues/159)
-* allow any swagger data to be overriden either via swagger-docs or via middlewares, fixes 
-  [#170](https://github.com/metosin/compojure-api/issues/170).
+* `clojure.tools.logging` is used with default uncaugt exception handling if it's found
+on the classpath. Fixes [#172](https://github.com/metosin/compojure-api/issues/172).
+* Both `api` and `defapi` produce identical swagger-docs. Fixes [#159](https://github.com/metosin/compojure-api/issues/159)
+* allow any swagger data to be overriden at runtime either via swagger-docs or via middlewares. Fixes [#170](https://github.com/metosin/compojure-api/issues/170).
 
 ```clojure
 [prismatic/plumbing "0.5.2] is available but we use "0.5.1"

--- a/project.clj
+++ b/project.clj
@@ -30,6 +30,7 @@
                              [lein-ring "0.9.7"]
                              [funcool/codeina "0.3.0"]]
                    :dependencies [[org.clojure/clojure "1.7.0"]
+                                  [org.clojure/tools.logging "0.3.1"]
                                   [peridot "0.4.1"]
                                   [javax.servlet/servlet-api "2.5"]
                                   [midje "1.8.2"]

--- a/project.clj
+++ b/project.clj
@@ -30,7 +30,6 @@
                              [lein-ring "0.9.7"]
                              [funcool/codeina "0.3.0"]]
                    :dependencies [[org.clojure/clojure "1.7.0"]
-                                  [org.clojure/tools.logging "0.3.1"]
                                   [peridot "0.4.1"]
                                   [javax.servlet/servlet-api "2.5"]
                                   [midje "1.8.2"]
@@ -44,6 +43,7 @@
                           :reload-paths ["src" "examples/src"]}
                    :source-paths ["examples/src" "examples/dev-src"]
                    :main examples.server}
+             :logging {:dependencies [[org.clojure/tools.logging "0.3.1"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0-RC2"]]}}
   :eastwood {:namespaces [:source-paths]
              :add-linters [:unused-namespaces]}
@@ -51,7 +51,7 @@
             :target "gh-pages/doc"
             :src-dir-uri "http://github.com/metosin/compojure-api/blob/master/"
             :src-linenum-anchor-prefix "L"}
-  :aliases {"all" ["with-profile" "dev:dev,1.8"]
+  :aliases {"all" ["with-profile" "dev:dev,logging:dev,1.8"]
             "start-thingie" ["run"]
             "aot-uberjar" ["with-profile" "uberjar" "do" "clean," "ring" "uberjar"]
             "test-ancient" ["midje"]

--- a/src/compojure/api/exception.clj
+++ b/src/compojure/api/exception.clj
@@ -1,7 +1,7 @@
 (ns compojure.api.exception
   (:require [ring.util.http-response :refer [internal-server-error bad-request]]
             [clojure.walk :refer [postwalk]]
-            [compojure.api.logging :as log]
+            [compojure.api.impl.logging :as logging]
             [schema.utils :as su])
   (:import [schema.utils ValidationError NamedError]
            [com.fasterxml.jackson.core JsonParseException]
@@ -17,7 +17,7 @@
    Error response only contains class of the Exception so that it won't accidentally
    expose secret details."
   [^Exception e _ _]
-  (log/log! :error e (.getMessage e))
+  (logging/log! :error e (.getMessage e))
   (internal-server-error {:type "unknown-exception"
                           :class (.getName (.getClass e))}))
 

--- a/src/compojure/api/exception.clj
+++ b/src/compojure/api/exception.clj
@@ -1,6 +1,7 @@
 (ns compojure.api.exception
   (:require [ring.util.http-response :refer [internal-server-error bad-request]]
             [clojure.walk :refer [postwalk]]
+            [compojure.api.logging :as log]
             [schema.utils :as su])
   (:import [schema.utils ValidationError NamedError]
            [com.fasterxml.jackson.core JsonParseException]
@@ -11,12 +12,12 @@
 ;;
 
 (defn safe-handler
-  "Prints stacktrace to console and returns safe error response.
+  "Writes :error to log with the exception message & stacktrace.
 
    Error response only contains class of the Exception so that it won't accidentally
    expose secret details."
   [^Exception e _ _]
-  (.printStackTrace e)
+  (log/log! :error e (.getMessage e))
   (internal-server-error {:type "unknown-exception"
                           :class (.getName (.getClass e))}))
 

--- a/src/compojure/api/impl/logging.clj
+++ b/src/compojure/api/impl/logging.clj
@@ -1,4 +1,4 @@
-(ns ^:no-doc compojure.api.logging
+(ns ^:no-doc compojure.api.impl.logging
   "Internal Compojure-api logging utility"
   (:require [clojure.string :as str]))
 

--- a/src/compojure/api/logging.clj
+++ b/src/compojure/api/logging.clj
@@ -1,0 +1,21 @@
+(ns compojure.api.logging)
+
+(defn resolve-logger []
+  (if (find-ns 'clojure.tools.logging)
+    (do
+      (require 'clojure.tools.logging)
+      (fn [level x]
+        (clojure.tools.logging/spy level x)))
+    (fn [level x & more]
+      (let [log (fn [level more]
+                  (println (.toUpperCase (name level)) (apply str more)))]
+        (if (instance? Throwable x)
+          (do
+            (log level (cons (.getMessage x) more))
+            (.printStackTrace x))
+          (log level (cons x more)))))))
+
+(def log (resolve-logger))
+
+(comment
+  (log :info (RuntimeException. "kosh")))

--- a/src/compojure/api/logging.clj
+++ b/src/compojure/api/logging.clj
@@ -1,20 +1,22 @@
-(ns compojure.api.logging
+(ns ^:no-doc compojure.api.logging
+  "Internal Compojure-api logging utility"
   (:require [clojure.string :as str]))
 
-;; default to console logging
-(defn log! [level x & more]
-  (let [log (fn [level more] (println (.toUpperCase (name level)) (str/join " - " more)))]
-    (if (instance? Throwable x)
-      (do
-        (log level more)
-        (.printStackTrace x))
-      (log level (into [x] more)))))
+;; Cursive-users
+(declare log!)
 
-;; use c.t.l logging if available
+;; use c.t.l logging if available, default to console logging
 (if (find-ns 'clojure.tools.logging)
   (eval
     `(do
        (require 'clojure.tools.logging)
        (defmacro ~'log! [& ~'args]
          `(do
-            (clojure.tools.logging/log ~@~'args))))))
+            (clojure.tools.logging/log ~@~'args)))))
+  (let [log (fn [level more] (println (.toUpperCase (name level)) (str/join " " more)))]
+    (defn log! [level x & more]
+      (if (instance? Throwable x)
+        (do
+          (log level more)
+          (.printStackTrace x))
+        (log level (into [x] more))))))


### PR DESCRIPTION
Fix for #172 - uses clojure.tools.logging for standard error logging if it's installed. Tests with and without the c.t.l -dependency.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/metosin/compojure-api/176)
<!-- Reviewable:end -->
