### PR TITLE
Memoize schema coercion

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -37,12 +37,14 @@
                                   [com.stuartsierra/component "0.3.1"]
                                   [reloaded.repl "0.2.1"]
                                   [http-kit "2.1.19"]
+                                  [criterium "0.4.3"]
                                   ; Required when using with Java 1.6
                                   [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]]
                    :ring {:handler examples.thingie/app
                           :reload-paths ["src" "examples/src"]}
                    :source-paths ["examples/src" "examples/dev-src"]
                    :main examples.server}
+             :perf {:jvm-opts ^:replace []}
              :logging {:dependencies [[org.clojure/tools.logging "0.3.1"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0-RC2"]]}}
   :eastwood {:namespaces [:source-paths]
@@ -55,5 +57,6 @@
             "start-thingie" ["run"]
             "aot-uberjar" ["with-profile" "uberjar" "do" "clean," "ring" "uberjar"]
             "test-ancient" ["midje"]
+            "perf" ["with-profile" "default,dev,perf"]
             "deploy!" ^{:doc "Recompile sources, then deploy if tests succeed."}
                       ["do" ["clean"] ["midje"] ["deploy" "clojars"]]})

--- a/test/compojure/api/perf_test.clj
+++ b/test/compojure/api/perf_test.clj
@@ -6,8 +6,18 @@
             [schema.core :as s]))
 
 ;;
-;; start repl with `lein perf repl`. note, all numbers are from Tommi's
-;; laptop.
+;; start repl with `lein perf repl`
+;; perf measured with the following setup:
+;;
+;; Model Name:	          MacBook Pro
+;; Model Identifier:	    MacBookPro11,3
+;; Processor Name:	      Intel Core i7
+;; Processor Speed:	      2,5 GHz
+;; Number of Processors:	1
+;; Total Number of Cores:	4
+;; L2 Cache (per Core):	  256 KB
+;; L3 Cache:	            6 MB
+;; Memory:	              16 GB
 ;;
 
 (defn title [s]
@@ -23,11 +33,12 @@
                     (s/optional-key :description) s/Str
                     :address (s/maybe {:street s/Str
                                        :country (s/enum "FI" "PO")})
-                    :orders [{:name s/Str
+                    :orders [{:name #"^k"
                               :price s/Any
                               :shipping s/Bool}]})
 
-(defn c-api-bench []
+(defn bench []
+
 
   (let [app (api
               (GET* "/30" []
@@ -37,9 +48,9 @@
     (title "GET JSON")
 
     (assert (= {:result 30} (second (call))))
-    (cc/quick-bench (call)))
+    (cc/bench (call)))
 
-  ; 32µs => 30µs (-6%)
+  ; 26µs => 26µs (-0%)
 
   (let [app (api
               (POST* "/plus" []
@@ -52,9 +63,9 @@
     (title "JSON POST with 2-way coercion")
 
     (assert (= {:result 30} (second (call))))
-    (cc/quick-bench (call)))
+    (cc/bench (call)))
 
-  ;; 104µs => 73µs (-30%)
+  ;; 87µs => 65µs (-25%)
 
   (let [app (api
               (context* "/a" []
@@ -70,9 +81,9 @@
     (title "JSON POST with 2-way coercion + contexts")
 
     (assert (= {:result 30} (second (call))))
-    (cc/quick-bench (call)))
+    (cc/bench (call)))
 
-  ;; 113µs => 80µs (-30%)
+  ;; 102µs => 78µs (-24%)
 
   (let [app (api
               (POST* "/echo" []
@@ -95,11 +106,11 @@
     (title "JSON POST with nested data")
 
     (s/check Order (second (call)))
-    (cc/quick-bench (call)))
+    (cc/bench (call)))
 
-  ;; 343µs => 175µs (-49%)
+  ;; 311µs => 194µs (-38%)
 
   )
 
 (comment
-  (c-api-bench))
+  (bench))

--- a/test/compojure/api/perf_test.clj
+++ b/test/compojure/api/perf_test.clj
@@ -2,9 +2,13 @@
   (:require [compojure.api.sweet :refer :all]
             [compojure.api.test-utils :refer :all]
             [criterium.core :as cc]
-            [midje.sweet :refer :all]
             [ring.util.http-response :refer :all]
             [schema.core :as s]))
+
+;;
+;; start repl with `lein perf repl`. note, all numbers are from Tommi's
+;; laptop.
+;;
 
 (defn title [s]
   (println
@@ -35,7 +39,7 @@
     (assert (= {:result 30} (second (call))))
     (cc/quick-bench (call)))
 
-  ; 32µs
+  ; 32µs => 30µs (-6%)
 
   (let [app (api
               (POST* "/plus" []
@@ -50,7 +54,7 @@
     (assert (= {:result 30} (second (call))))
     (cc/quick-bench (call)))
 
-  ;; 104µs
+  ;; 104µs => 73µs (-30%)
 
   (let [app (api
               (context* "/a" []
@@ -68,7 +72,7 @@
     (assert (= {:result 30} (second (call))))
     (cc/quick-bench (call)))
 
-  ;; 113µs
+  ;; 113µs => 80µs (-30%)
 
   (let [app (api
               (POST* "/echo" []
@@ -93,9 +97,9 @@
     (s/check Order (second (call)))
     (cc/quick-bench (call)))
 
-  ;; 343µs
+  ;; 343µs => 175µs (-49%)
 
   )
 
-
-(c-api-bench)
+(comment
+  (c-api-bench))

--- a/test/compojure/api/perf_test.clj
+++ b/test/compojure/api/perf_test.clj
@@ -1,0 +1,101 @@
+(ns compojure.api.perf-test
+  (:require [compojure.api.sweet :refer :all]
+            [compojure.api.test-utils :refer :all]
+            [criterium.core :as cc]
+            [midje.sweet :refer :all]
+            [ring.util.http-response :refer :all]
+            [schema.core :as s]))
+
+(defn title [s]
+  (println
+    (str "\n\u001B[35m"
+         (apply str (repeat (+ 6 (count s)) "#"))
+         "\n## " s " ##\n"
+         (apply str (repeat (+ 6 (count s)) "#"))
+         "\u001B[0m\n")))
+
+(s/defschema Order {:id s/Str
+                    :name s/Str
+                    (s/optional-key :description) s/Str
+                    :address (s/maybe {:street s/Str
+                                       :country (s/enum "FI" "PO")})
+                    :orders [{:name s/Str
+                              :price s/Any
+                              :shipping s/Bool}]})
+
+(defn c-api-bench []
+
+  (let [app (api
+              (GET* "/30" []
+                (ok {:result 30})))
+        call #(get* app "/30")]
+
+    (title "GET JSON")
+
+    (assert (= {:result 30} (second (call))))
+    (cc/quick-bench (call)))
+
+  ; 32µs
+
+  (let [app (api
+              (POST* "/plus" []
+                :return {:result s/Int}
+                :body-params [x :- s/Int, y :- s/Int]
+                (ok {:result (+ x y)})))
+        data (json {:x 10, :y 20})
+        call #(post* app "/plus" data)]
+
+    (title "JSON POST with 2-way coercion")
+
+    (assert (= {:result 30} (second (call))))
+    (cc/quick-bench (call)))
+
+  ;; 104µs
+
+  (let [app (api
+              (context* "/a" []
+                (context* "/b" []
+                  (context* "/c" []
+                    (POST* "/plus" []
+                      :return {:result s/Int}
+                      :body-params [x :- s/Int, y :- s/Int]
+                      (ok {:result (+ x y)}))))))
+        data (json {:x 10, :y 20})
+        call #(post* app "/a/b/c/plus" data)]
+
+    (title "JSON POST with 2-way coercion + contexts")
+
+    (assert (= {:result 30} (second (call))))
+    (cc/quick-bench (call)))
+
+  ;; 113µs
+
+  (let [app (api
+              (POST* "/echo" []
+                :return Order
+                :body [order Order]
+                (ok order)))
+        data (json {:id "123"
+                    :name "Tommi's order"
+                    :description "Totally great order"
+                    :address {:street "Randomstreet 123"
+                              :country "FI"}
+                    :orders [{:name "k1"
+                              :price 123.0
+                              :shipping true}
+                             {:name "k2"
+                              :price 42.0
+                              :shipping false}]})
+        call #(post* app "/echo" data)]
+
+    (title "JSON POST with nested data")
+
+    (s/check Order (second (call)))
+    (cc/quick-bench (call)))
+
+  ;; 343µs
+
+  )
+
+
+(c-api-bench)


### PR DESCRIPTION
Instead of creating the `coercer` on every request, we cache those via `clojure.core/memoize`. There will be a cache entry for all `schema` & `matcher` -pairs. Measured latency via `api` decreases by up to 40% in the new criterium tests, depending on the Schema complexity.