### PR TITLE
Not ready: Exception logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Unreleased
+
+- Log any exceptions and add option to define function used to
+log exceptions. ([#191](https://github.com/metosin/compojure-api/issues/191))
+  - Previously only default exception handler logged exceptions, but
+  `request-validation`, `request-parsing`, `response-validation` or
+  `schema-error` exceptions were not logged. Now they are logged.
+  - To disable logging completely, provide no-op `log-fn`:
+  `:exceptions {:log-fn (fn [e] nil)}`
+
 ## 0.24.4 (13.1.2016)
 
 **[compare](https://github.com/metosin/compojure-api/compare/0.24.3...0.24.4)**

--- a/project.clj
+++ b/project.clj
@@ -30,6 +30,7 @@
                              [lein-ring "0.9.7"]
                              [funcool/codeina "0.3.0"]]
                    :dependencies [[org.clojure/clojure "1.7.0"]
+                                  [slingshot "0.12.2"]
                                   [peridot "0.4.2"]
                                   [javax.servlet/servlet-api "2.5"]
                                   [midje "1.8.3"]

--- a/src/compojure/api/exception.clj
+++ b/src/compojure/api/exception.clj
@@ -11,13 +11,15 @@
 ;; Default exception handlers
 ;;
 
+(defn log-exception [^Exception e]
+  (logging/log! :error e (.getMessage e)))
+
 (defn safe-handler
   "Writes :error to log with the exception message & stacktrace.
 
    Error response only contains class of the Exception so that it won't accidentally
    expose secret details."
   [^Exception e _ _]
-  (logging/log! :error e (.getMessage e))
   (internal-server-error {:type "unknown-exception"
                           :class (.getName (.getClass e))}))
 

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -9,7 +9,6 @@
             [ring.swagger.common :refer :all]
             [ring.swagger.json-schema :as js]
             [ring.util.http-response :refer [internal-server-error]]
-            [slingshot.slingshot :refer [throw+]]
             [schema.core :as s]
             [schema.coerce :as sc]
             [schema.utils :as su]
@@ -88,7 +87,8 @@
           (let [coerce (coercer (value-of schema) matcher)
                 body (coerce (:body response))]
             (if (su/error? body)
-              (throw+ (assoc body :type ::ex/response-validation))
+              (throw (ex-info "Response validation error"
+                              (assoc body :type ::ex/response-validation)))
               (assoc response
                 ::serializable? true
                 :body body)))
@@ -105,7 +105,7 @@
        (let [coerce# (~+compojure-api-coercer+ ~schema matcher#)
              result# (coerce# value#)]
          (if (su/error? result#)
-           (throw+ (assoc result# :type ::ex/request-validation))
+           (throw (ex-info "Request valiudation failed" (assoc result# :type ::ex/request-validation)))
            result#))
        value#)))
 

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -105,7 +105,7 @@
        (let [coerce# (~+compojure-api-coercer+ ~schema matcher#)
              result# (coerce# value#)]
          (if (su/error? result#)
-           (throw (ex-info "Request valiudation failed" (assoc result# :type ::ex/request-validation)))
+           (throw (ex-info "Request validation failed" (assoc result# :type ::ex/request-validation)))
            result#))
        value#)))
 

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -64,7 +64,7 @@
             (log-fn e)
             ; FIXME: Used for validate
             (if (rethrow-exceptions? request)
-              (throw)
+              (throw e)
               (if-let [handler (get handlers type)]
                 (call-error-handler handler e data request)
                 (call-error-handler default-handler e data request)))))))))

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -50,7 +50,8 @@
   "Catches all exceptions and delegates to right error handler accoring to :type of Exceptions
    - **:handlers** - a map from exception type to handler
      - **:compojure.api.exception/default** - Handler used when exception type doesn't match other handler,
-                                              by default prints stack trace."
+                                              by default prints stack trace.
+   - **:log-fn**   - a function to call with exception"
   [handler {:keys [handlers log-fn]}]
   (let [default-handler (get handlers ::ex/default ex/safe-handler)
         log-fn (or log-fn ex/log-exception)]
@@ -185,6 +186,9 @@
                                        :compojure.api.exception/request-parsing     compojure.api.exception/request-parsing-handler
                                        :compojure.api.exception/response-validation compojure.api.exception/response-validation-handler
                                        :compojure.api.exception/default             compojure.api.exception/safe-handler}
+
+                                      Note: Because the handlers are merged into default handlers map, to disable default handler you
+                                      need to provide `nil` value as handler.
 
                                       Note: To catch Schema errors use {:schema.core/error compojure.api.exception/schema-error-handler}
 

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -61,14 +61,13 @@
         (handler request)
         (catch Throwable e
           (let [{:keys [type] :as data} (ex-data e)
-                type (or (get ex/legacy-exception-types type) type)]
+                type (or (get ex/legacy-exception-types type) type)
+                handler (or (get handlers type) default-handler)]
             (log-fn e)
             ; FIXME: Used for validate
             (if (rethrow-exceptions? request)
               (throw e)
-              (if-let [handler (get handlers type)]
-                (call-error-handler handler e data request)
-                (call-error-handler default-handler e data request)))))))))
+              (call-error-handler handler e data request))))))))
 
 ;;
 ;; Component integration

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -859,7 +859,8 @@
   (let [app (api
               {:exceptions {:handlers {::ex/request-validation custom-validation-error-handler
                                        ::ex/request-parsing custom-validation-error-handler
-                                       ::ex/response-validation custom-validation-error-handler}}}
+                                       ::ex/response-validation custom-validation-error-handler}
+                            :log-fn (constantly nil)}}
               (swagger-docs)
               (POST* "/get-long" []
                 :body [body {:x Long}]
@@ -891,7 +892,8 @@
 (fact "exceptions options with custom exception and error handler"
   (let [app (api
               {:exceptions {:handlers {::ex/default custom-exception-handler
-                                       ::custom-error custom-error-handler}}}
+                                       ::custom-error custom-error-handler}
+                            :log-fn (constantly nil)}}
               (swagger-docs)
               (GET* "/some-exception" []
                 (throw (new RuntimeException)))
@@ -929,7 +931,8 @@
     => (throws AssertionError))
   (facts "Old handler functions work, with a warning"
     (let [app (api
-                {:exceptions {:handlers {::ex/default old-ex-handler}}}
+                {:exceptions {:handlers {::ex/default old-ex-handler}
+                              :log-fn (constantly nil)}}
                 (GET* "/" []
                   (throw (RuntimeException.))))]
       (let [[status body] (get* app "/")]
@@ -943,7 +946,8 @@
 
 (fact "handling schema.core/error"
   (let [app (api
-              {:exceptions {:handlers {:schema.core/error ex/schema-error-handler}}}
+              {:exceptions {:handlers {:schema.core/error ex/schema-error-handler}
+                            :log-fn (constantly nil)}}
               (GET* "/:a" []
                 :path-params [a :- s/Str]
                 (ok (s/with-fn-validation (schema-error a)))))]

--- a/test/compojure/api/middleware_test.clj
+++ b/test/compojure/api/middleware_test.clj
@@ -43,10 +43,10 @@
     (without-err
       (let [exception (RuntimeException. "kosh")
             exception-class (.getName (.getClass exception))
-            failure (fn [_] (throw exception))]
+            handler (-> (fn [_] (throw exception))
+                        (wrap-exceptions {}))]
 
         (fact "converts exceptions into safe internal server errors"
-          ((wrap-exceptions failure (:handlers (:exceptions api-middleware-defaults))) ..request..)
-          => (contains {:status status/internal-server-error
-                        :body (contains {:class exception-class
-                                         :type "unknown-exception"})}))))))
+          (handler {}) => (contains {:status status/internal-server-error
+                                     :body (contains {:class exception-class
+                                                      :type "unknown-exception"})}))))))


### PR DESCRIPTION
PR for comments.

This addresses #191 but still needs some consideration.

- Should error response and error logging be separated? I think so.
- Should EVERY exception be logged? Maybe not by default.
    - Currently request validation, request parsing and response validation exceptions are not logged by default
    - Logging those can cause excessive log trafic
    - Should be possible to disable logging for specific types?
    - Default could be to not log exceptions which are not currently logged?
- Currently tests log A LOT STUFF, the default need to change or tests need to use something to silence noice

One solution would be define `log-fn` using same kind of `type` => `fn` map which is used for handlers.

@ikitommi Ideas?