### PR TITLE
Improve docstrings

### DIFF
--- a/src/compojure/api/common.clj
+++ b/src/compojure/api/common.clj
@@ -36,13 +36,13 @@
 
 (defn assoc-map-ordered
   "assocs a value into a map, forcing the implementation to be
-   clojure.lang.PersistentArrayMap instead of clojure.lang.PersistentHashMap,
-   thus retaining the insertion order. O(n)."
+  clojure.lang.PersistentArrayMap instead of clojure.lang.PersistentHashMap,
+  thus retaining the insertion order. O(n)."
   [m k v] (apply array-map (into (vec (apply concat m)) [k v])))
 
 (defmacro map-of
   "creates map with symbol names as keywords as keys and
-   symbol values as values."
+  symbol values as values."
   [& syms]
   `(zipmap ~(vec (map keyword syms)) ~(vec syms)))
 

--- a/src/compojure/api/core.clj
+++ b/src/compojure/api/core.clj
@@ -23,16 +23,16 @@
 
 (defmacro api
   "Returns a ring handler wrapped in compojure.api.middleware/api-middlware.
-   Creates the route-table at compile-time and passes that into the request via
-   ring-swagger middlewares. The mounted api-middleware can be configured by
-   optional options map as the first parameter:
+  Creates the route-table at compile-time and passes that into the request via
+  ring-swagger middlewares. The mounted api-middleware can be configured by
+  optional options map as the first parameter:
 
-       (api
-         {:formats [:json :edn]}
-         (context* \"/api\" []
-           ...))
+      (api
+        {:formats [:json :edn]}
+        (context* \"/api\" []
+        ...))
 
-   ... see compojure.api.middleware/api-middleware for possible options."
+  ... see compojure.api.middleware/api-middleware for possible options."
   [& body]
   (let [[opts body] (extract-parameters body)]
     `(api-middleware-with-routes
@@ -41,16 +41,16 @@
 
 (defmacro defapi
   "Returns a ring handler wrapped in a `api`. Behind the scenes,
-   creates the route-table at compile-time and passes that into the request via
-   ring-swagger middlewares. The mounted api-middleware can be configured by
-   optional options map as the first parameter:
+  creates the route-table at compile-time and passes that into the request via
+  ring-swagger middlewares. The mounted api-middleware can be configured by
+  optional options map as the first parameter:
 
-       (defapi app
-         {:formats [:json :edn]}
-         (context* \"/api\" []
-           ...))
+      (defapi app
+        {:formats [:json :edn]}
+        (context* \"/api\" []
+          ...))
 
-   ... see compojure.api.middleware/api-middleware for possible options."
+  ... see compojure.api.middleware/api-middleware for possible options."
   [name & body]
   `(def ~name
      (api ~@body)))

--- a/src/compojure/api/core.clj
+++ b/src/compojure/api/core.clj
@@ -21,7 +21,8 @@
         (mw/wrap-options (select-keys meta [:routes :lookup]))
         (with-meta meta))))
 
-(defmacro api
+(defmacro
+  ^{:doc (str
   "Returns a ring handler wrapped in compojure.api.middleware/api-middlware.
   Creates the route-table at compile-time and passes that into the request via
   ring-swagger middlewares. The mounted api-middleware can be configured by
@@ -32,14 +33,18 @@
         (context* \"/api\" []
         ...))
 
-  ... see compojure.api.middleware/api-middleware for possible options."
+  Middleware options:
+
+  " (:doc (meta #'mw/api-middleware)))}
+  api
   [& body]
   (let [[opts body] (extract-parameters body)]
     `(api-middleware-with-routes
        (routes/api-root ~@body)
        ~opts)))
 
-(defmacro defapi
+(defmacro
+  ^{:doc (str
   "Returns a ring handler wrapped in a `api`. Behind the scenes,
   creates the route-table at compile-time and passes that into the request via
   ring-swagger middlewares. The mounted api-middleware can be configured by
@@ -50,7 +55,10 @@
         (context* \"/api\" []
           ...))
 
-  ... see compojure.api.middleware/api-middleware for possible options."
+  Middleware options:
+
+  " (:doc (meta #'mw/api-middleware)))}
+  defapi
   [name & body]
   `(def ~name
      (api ~@body)))

--- a/src/compojure/api/exception.clj
+++ b/src/compojure/api/exception.clj
@@ -14,8 +14,8 @@
 (defn safe-handler
   "Writes :error to log with the exception message & stacktrace.
 
-   Error response only contains class of the Exception so that it won't accidentally
-   expose secret details."
+  Error response only contains class of the Exception so that it won't accidentally
+  expose secret details."
   [^Exception e _ _]
   (logging/log! :error e (.getMessage e))
   (internal-server-error {:type "unknown-exception"

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -97,7 +97,7 @@
 
 (s/defn src-coerce!
   "Return source code for coerce! for a schema with coercion type,
-   extracted from a key in a ring request."
+  extracted from a key in a ring request."
   [schema, key, type :- mw/CoercionType]
   (assert (not (#{:query :json} type)) (str type " is DEPRECATED since 0.22.0. Use :body or :string instead."))
   `(let [value# (keywordize-keys (~key ~+compojure-api-request+))]
@@ -324,9 +324,9 @@
 
 (defn- destructure-compojure-api-request
   "Returns a vector of three elements:
-   - new lets list
-   - bindings form for compojure route
-   - symbol to which request will be bound"
+  - new lets list
+  - bindings form for compojure route
+  - symbol to which request will be bound"
   [lets arg]
   (cond
     ;; GET "/route" []

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -48,9 +48,9 @@
 
 (defn wrap-exceptions
   "Catches all exceptions and delegates to correct error handler according to :type of Exceptions
-   - **:handlers** - a map from exception type to handler
-     - **:compojure.api.exception/default** - Handler used when exception type doesn't match other handler,
-                                              by default prints stack trace."
+  - **:handlers** - a map from exception type to handler
+    - **:compojure.api.exception/default** - Handler used when exception type doesn't match other handler,
+                                             by default prints stack trace."
   [handler {:keys [handlers]}]
   (let [default-handler (get handlers ::ex/default ex/safe-handler)]
     (assert (fn? default-handler) "Default exception handler must be a function.")
@@ -149,8 +149,8 @@
 
 (defn serializable?
   "Predicate which returns true if the response body is serializable.
-   That is, return type is set by :return compojure-api key or it's
-   a collection."
+  That is, return type is set by :return compojure-api key or it's
+  a collection."
   [_ {:keys [body] :as response}]
   (when response
     (or (:compojure.api.meta/serializable? response)
@@ -173,39 +173,39 @@
 ;; TODO: test all options! (https://github.com/metosin/compojure-api/issues/137)
 (defn api-middleware
   "Opinionated chain of middlewares for web apis. Takes options-map, with namespaces
-   options for the used middlewares (see middlewares for full details on options):
+  options for the used middlewares (see middlewares for full details on options):
 
-   - **:exceptions**                for *compojure.api.middleware/wrap-exceptions*
-       - **:handlers**                Map of error handlers for different exception types, type refers to `:type` key in ExceptionInfo data.
-                                      An error handler is a function of exception, ExceptionInfo data and request to response.
-                                      Default:
-                                      {:compojure.api.exception/request-validation  compojure.api.exception/request-validation-handler
-                                       :compojure.api.exception/request-parsing     compojure.api.exception/request-parsing-handler
-                                       :compojure.api.exception/response-validation compojure.api.exception/response-validation-handler
-                                       :compojure.api.exception/default             compojure.api.exception/safe-handler}
+  - **:exceptions**                for *compojure.api.middleware/wrap-exceptions*
+      - **:handlers**                Map of error handlers for different exception types, type refers to `:type` key in ExceptionInfo data.
+                                     An error handler is a function of exception, ExceptionInfo data and request to response.
+                                     Default:
+                                     {:compojure.api.exception/request-validation  compojure.api.exception/request-validation-handler
+                                      :compojure.api.exception/request-parsing     compojure.api.exception/request-parsing-handler
+                                      :compojure.api.exception/response-validation compojure.api.exception/response-validation-handler
+                                      :compojure.api.exception/default             compojure.api.exception/safe-handler}
 
-                                      Note: To catch Schema errors use {:schema.core/error compojure.api.exception/schema-error-handler}
+                                     Note: To catch Schema errors use {:schema.core/error compojure.api.exception/schema-error-handler}
 
-                                      Note: Adding an alias for exception namespace makes it easier to define these options.
+                                     Note: Adding an alias for exception namespace makes it easier to define these options.
 
-   - **:format**                    for ring-middleware-format middlewares
-       - **:formats**                 sequence of supported formats, e.g. `[:json-kw :edn]`
-       - **:params-opts**             for *ring.middleware.format-params/wrap-restful-params*,
-                                      e.g. `{:transit-json {:handlers readers}}`
-       - **:response-opts**           for *ring.middleware.format-params/wrap-restful-response*,
-                                      e.g. `{:transit-json {:handlers writers}}`
+  - **:format**                    for ring-middleware-format middlewares
+      - **:formats**                 sequence of supported formats, e.g. `[:json-kw :edn]`
+      - **:params-opts**             for *ring.middleware.format-params/wrap-restful-params*,
+                                     e.g. `{:transit-json {:handlers readers}}`
+      - **:response-opts**           for *ring.middleware.format-params/wrap-restful-response*,
+                                     e.g. `{:transit-json {:handlers writers}}`
 
-   - **:ring-swagger**              options for ring-swagger's swagger-json method.
-                                    e.g. `{:ignore-missing-mappings? true}`
+  - **:ring-swagger**              options for ring-swagger's swagger-json method.
+                                   e.g. `{:ignore-missing-mappings? true}`
 
-   - **:coercion**                  A function from request->type->coercion-matcher, used
-                                    in endpoint coercion for :json, :query and :response.
-                                    Defaults to `compojure.api.middleware/default-coercion-matchers`
+  - **:coercion**                  A function from request->type->coercion-matcher, used
+                                   in endpoint coercion for :json, :query and :response.
+                                   Defaults to `compojure.api.middleware/default-coercion-matchers`
 
-   - **:components**                Components which should be accessible to handlers using
-                                    :components restructuring. (If you are using defapi,
-                                    you might want to take look at using wrap-components
-                                    middleware manually.)"
+  - **:components**                Components which should be accessible to handlers using
+                                   :components restructuring. (If you are using defapi,
+                                   you might want to take look at using wrap-components
+                                   middleware manually.)"
   [handler & [options]]
   (let [options (deep-merge api-middleware-defaults options)
         {:keys [exceptions format components]} options

--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -275,22 +275,22 @@
 
 (defmacro swagger-docs
   "Route to serve the swagger api-docs. If the first
-   parameter is a String, it is used as a url for the
-   api-docs, otherwise \"/swagger.json\" will be used.
-   Next Keyword value pairs OR a map for meta-data.
-   Meta-data can be any valid swagger 2.0 data. Common
-   case is to introduce API Info and Tags here:
+  parameter is a String, it is used as a url for the
+  api-docs, otherwise \"/swagger.json\" will be used.
+  Next Keyword value pairs OR a map for meta-data.
+  Meta-data can be any valid swagger 2.0 data. Common
+  case is to introduce API Info and Tags here:
 
-       {:info {:version \"1.0.0\"
-               :title \"Sausages\"
-               :description \"Sausage description\"
-               :termsOfService \"http://helloreverb.com/terms/\"
-               :contact {:name \"My API Team\"
-                         :email \"foo@example.com\"
-                         :url \"http://www.metosin.fi\"}
-               :license {:name: \"Eclipse Public License\"
-                         :url: \"http://www.eclipse.org/legal/epl-v10.html\"}}
-        :tags [{:name \"sausages\", :description \"Sausage api-set}]}"
+      {:info {:version \"1.0.0\"
+              :title \"Sausages\"
+              :description \"Sausage description\"
+              :termsOfService \"http://helloreverb.com/terms/\"
+              :contact {:name \"My API Team\"
+                        :email \"foo@example.com\"
+                        :url \"http://www.metosin.fi\"}
+              :license {:name: \"Eclipse Public License\"
+                        :url: \"http://www.eclipse.org/legal/epl-v10.html\"}}
+       :tags [{:name \"sausages\", :description \"Sausage api-set}]}"
   [& body]
   (let [[path key-values] (if (string? (first body))
                             [(first body) (rest body)]
@@ -318,9 +318,9 @@
 
 (defmacro swaggered
   "DEPRECATED. Use context* with :tags instead:
-    (context* \"/api\"
-      :tags [\"api\"]
-      ...)"
+  (context* \"/api\"
+    :tags [\"api\"]
+    ...)"
   [api-name & body]
   (deprecated! "swaggered is deprecated and removed soon, see docs for details.")
   (let [[_ body] (extract-parameters body)]


### PR DESCRIPTION
Fixes docstrings to constantly use proper indentation.

Includes api-middleware docstring in api and defapi docstrings. @ikitommi  would you check if this works on Cursive?