### PR TITLE
Route-validation as an api-option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@
 
 * **BREAKING** Vanilla Compojure routes will not produce any swagger-docs (as they do not satisfy the 
 `Routing` protocol. They can still be used for handling request, just without docs.
-  * **TODO**: a new api-level option to declare how to handle routes not satisfying the `Routing` protocol (fail, warn or ignore)
+  * a new api-level option `[:api :invalid-routes-fn]` to declare how to handle routes not satisfying
+  the `Routing` protocol. Default implementation logs invalid routes as WARNINGs.
 
 * **BREAKING** compojure.core imports are removed from `compojure.api.sweet`:
   * `let-request`, `routing`, `wrap-routes`

--- a/src/compojure/api/api.clj
+++ b/src/compojure/api/api.clj
@@ -5,13 +5,18 @@
             [compojure.api.routes :as routes]
             [compojure.api.common :as common]
             [clojure.tools.macro :as macro]
-            [ring.swagger.swagger2 :as swagger2]))
+            [ring.swagger.common :as rsc]))
+
+(def api-defaults
+  (merge
+    middleware/api-middleware-defaults
+    {:api {:invalid-routes-fn routes/log-invalid-child-routes}}))
 
 (defn
   ^{:doc (str
   "Returns a ring handler wrapped in compojure.api.middleware/api-middlware.
-  Creates the route-table at run-time and passes that into the request via
-  ring-swagger middlewares. The mounted api-middleware can be configured by
+  Creates the route-table at run-time and injects that into the request via
+  middlewares. Api and the mounted api-middleware can be configured by
   optional options map as the first parameter:
 
       (api
@@ -19,18 +24,27 @@
         (context \"/api\" []
           ...))
 
-  API middleware options:
+  ### direct api options:
+
+  - **:api**                       All api options are under `:api`.
+    - **:invalid-routes-fn**         A 2-arity function taking handler and a sequence of
+                                     invalid routes (not satisfying compojure.api.route.Routing)
+                                     setting value to nil ignores invalid routes completely.
+                                     defaults to `compojure.api.routes/log-invalid-child-routes`
+
+  ### api-middleware options
 
   " (:doc (meta #'compojure.api.middleware/api-middleware)))}
   api
   [& body]
   (let [[options handlers] (common/extract-parameters body)
+        options (rsc/deep-merge api-defaults options)
         handler (apply core/routes handlers)
-        routes (routes/get-routes handler)
+        routes (routes/get-routes handler (:api options))
         paths (-> routes routes/ring-swagger-paths swagger/transform-operations)
-        lookup (routes/route-lookup-table handler)
+        lookup (routes/route-lookup-table routes)
         api-handler (-> handler
-                        (middleware/api-middleware options)
+                        (middleware/api-middleware (dissoc options :api))
                         (middleware/wrap-options {:paths paths
                                                   :lookup lookup}))]
     (routes/create nil nil {} [handler] api-handler)))

--- a/src/compojure/api/api.clj
+++ b/src/compojure/api/api.clj
@@ -26,11 +26,11 @@
   [& body]
   (let [[options handlers] (common/extract-parameters body)
         handler (apply core/routes handlers)
-        paths (swagger/ring-swagger-paths handler)
+        routes (routes/get-routes handler)
+        paths (-> routes routes/ring-swagger-paths swagger/transform-operations)
         lookup (routes/route-lookup-table handler)
         api-handler (-> handler
                         (middleware/api-middleware options)
-                        ;; TODO: wrap just the handler
                         (middleware/wrap-options {:paths paths
                                                   :lookup lookup}))]
     (routes/create nil nil {} [handler] api-handler)))

--- a/src/compojure/api/common.clj
+++ b/src/compojure/api/common.clj
@@ -34,3 +34,9 @@
 
     :else
     [{} (seq c)]))
+
+(defn group-with
+  "Groups a sequence with predicate returning a tuple of sequences."
+  [pred coll]
+  [(seq (filter pred coll))
+   (seq (remove pred coll))])

--- a/src/compojure/api/routes.clj
+++ b/src/compojure/api/routes.clj
@@ -50,7 +50,6 @@
           data {:path path
                 :method method
                 :info info
-                :childs childs
                 :invalid invalid-childs}]
       (if *fail-on-missing-route-info*
         (throw (ex-info message data))

--- a/src/compojure/api/routes.clj
+++ b/src/compojure/api/routes.clj
@@ -76,17 +76,17 @@
     (update-in info [:parameters :path] #(dissoc (merge (string-path-parameters path) %) s/Keyword))
     info))
 
-(defn ring-swagger-paths [handler]
+(defn ring-swagger-paths [routes]
   {:paths
    (reduce
     (fn [acc [path method info]]
       (update-in
-       acc [path method]
-       (fn [old-info]
-         (let [info (or old-info info)]
-           (ensure-path-parameters path info)))))
+        acc [path method]
+        (fn [old-info]
+          (let [info (or old-info info)]
+            (ensure-path-parameters path info)))))
     (linked/map)
-    (get-routes handler))})
+    routes)})
 
 ;;
 ;; Route lookup
@@ -97,7 +97,7 @@
         :when (> freq 1)] id))
 
 (defn route-lookup-table [handler]
-  (let [entries (for [[path endpoints] (:paths (ring-swagger-paths handler))
+  (let [entries (for [[path endpoints] (-> handler get-routes ring-swagger-paths :paths)
                       [method {:keys [x-name parameters]}] endpoints
                       :let [params (:path parameters)]
                       :when x-name]

--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -37,9 +37,8 @@
 ;; routes
 ;;
 
-(defn ring-swagger-paths [handler]
-  (->> handler
-       routes/ring-swagger-paths
+(defn transform-operations [swagger]
+  (->> swagger
        (swagger2/transform-operations routes/non-nil-routes)
        (swagger2/transform-operations routes/strip-no-doc-endpoints)))
 

--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -90,6 +90,7 @@
 
 (defn swagger-spec-path [app]
   (some-> app
+          routes/get-routes
           routes/route-lookup-table
           ::swagger
           keys

--- a/test/compojure/api/common_test.clj
+++ b/test/compojure/api/common_test.clj
@@ -5,3 +5,7 @@
 (fact "map-of"
   (let [a 1 b true c [:abba :jabba]]
     (map-of a b c) => {:a 1 :b true :c [:abba :jabba]}))
+
+(fact "group-with"
+  (group-with pos? [1 -10 2 -4 -1 999]) => [[1 2 999] [-10 -4 -1]]
+  (group-with pos? [1 2 999]) => [[1 2 999] nil])

--- a/test/compojure/api/routes_test.clj
+++ b/test/compojure/api/routes_test.clj
@@ -86,3 +86,19 @@
   (routes/get-routes (routes (routes))) => []
   (routes/get-routes (routes (swagger-ui))) => []
   (routes/get-routes (routes (routes (GET "/ping" [] "pong")))) => [["/ping" :get {}]])
+
+(fact "invalid route options"
+  (let [r (routes (constantly nil))]
+
+    (fact "ignore 'em all"
+      (routes/get-routes r) => []
+      (routes/get-routes r nil) => []
+      (routes/get-routes r {:invalid-routes-fn nil}) => [])
+
+    (fact "log warnings"
+      (routes/get-routes r {:invalid-routes-fn routes/log-invalid-child-routes}) => []
+      (provided
+        (compojure.api.impl.logging/log! :warn irrelevant) => irrelevant :times 1))
+
+    (fact "throw exception"
+      (routes/get-routes r {:invalid-routes-fn routes/fail-on-invalid-child-routes})) => throws))

--- a/test/compojure/api/swagger_test.clj
+++ b/test/compojure/api/swagger_test.clj
@@ -55,13 +55,12 @@
         (GET+ "/true" [] identity))) => {"/api/xxx/true" {:get {}}})
 
   (fact "Vanilla Compojure defroutes are NOT followed"
-    (ignore-non-documented-route-warning
-      (compojure.core/defroutes even-more-routes (GET "/even" [] identity))
-      (compojure.core/defroutes more-routes (context "/more" [] even-more-routes))
-      (extract-paths
-        (context "/api" []
-          (GET "/true" [] identity)
-          more-routes)) => {"/api/true" {:get {}}}))
+    (compojure.core/defroutes even-more-routes (GET "/even" [] identity))
+    (compojure.core/defroutes more-routes (context "/more" [] even-more-routes))
+    (extract-paths
+      (context "/api" []
+        (GET "/true" [] identity)
+        more-routes)) => {"/api/true" {:get {}}})
 
   (fact "Compojure Api defroutes and def routes are followed"
     (def even-more-routes (GET "/even" [] identity))

--- a/test/compojure/api/test_utils.clj
+++ b/test/compojure/api/test_utils.clj
@@ -94,7 +94,7 @@
 ;;
 
 (defn extract-paths [app]
-  (:paths (routes/ring-swagger-paths app)))
+  (-> app routes/get-routes routes/ring-swagger-paths :paths))
 
 (defn get-spec [app]
   (let [[status spec] (get* app "/swagger.json" {})]

--- a/test/compojure/api/test_utils.clj
+++ b/test/compojure/api/test_utils.clj
@@ -81,15 +81,6 @@
     [status (parse-body body)]))
 
 ;;
-;; Route compilation
-;;
-
-(defmacro ignore-non-documented-route-warning [& body]
-  `(with-out-str
-     (binding [routes/*fail-on-missing-route-info* false]
-       ~@body)))
-
-;;
 ;; get-spec
 ;;
 


### PR DESCRIPTION
* don't check at route creation time
* optionally check at api-creation time
* remove the *fail-on-missing-route-info* dynamic var

```clj
(fact "handling invalid routes with api"
  (let [invalid-routes (routes (constantly nil))]

    (fact "by default, logs the exception"
      (api invalid-routes) => truthy
      (provided
        (compojure.api.impl.logging/log! :warn irrelevant) => irrelevant :times 1))

    (fact "ignoring invalid routes doesn't log"
      (api {:api {:invalid-routes-fn nil}} invalid-routes) => truthy
      (provided
        (compojure.api.impl.logging/log! :warn irrelevant) => irrelevant :times 0))

    (fact "throwing exceptions"
      (api {:api {:invalid-routes-fn routes/fail-on-invalid-child-routes}} invalid-routes)) => throws))
```