### PR TITLE
Middleware fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,9 +52,14 @@
 Previously required a `type => matcher` map. Options are checked against `type => matcher` coercion input, and a
 descriptive error is thrown when api is created with the old options format.
 
-* **TODO**: Middlewares
+* **BREAKING**: Renamed `middlewares` to `middleware` and `:middlewares` metahandler to `:middleware`
 
-* **BREAKING** Renamed `middlewares` to `middleware` and `:middlewares` metahandler to `:middleware`
+* **BREAKING**: Middleware must be defined as data: both our forms take a vector
+of middleware containing either a) fully configured mws (function)
+or b) a middleware templates in form [function args]. Nothing new, just best practices.
+  * You can also use anonymous functions to create middleware with correct parameters:
+  `(middleware [#(wrap-foo % {:opts :bar})])`
+  * Similar to [duct](https://github.com/weavejester/duct/wiki/Components#handlers)
 
 ### Migration guide
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ descriptive error is thrown when api is created with the old options format.
 
 * **TODO**: Middlewares
 
+* **BREAKING** Renamed `middlewares` to `middleware` and `:middlewares` metahandler to `:middleware`
+
 ### Migration guide
 
 https://github.com/metosin/compojure-api/wiki/Migration-Guide-to-1.0.0

--- a/examples/src/examples/thingie.clj
+++ b/examples/src/examples/thingie.clj
@@ -188,7 +188,7 @@
 
       (POST "/upload" []
         :multipart-params [file :- TempFileUpload]
-        :middlewares [wrap-multipart-params]
+        :middleware [wrap-multipart-params]
         (ok (dissoc file :tempfile))))
 
     (context "/component" []

--- a/src/compojure/api/core.clj
+++ b/src/compojure/api/core.clj
@@ -33,13 +33,13 @@
   (let [handlers (keep identity handlers)]
     (routes/create nil nil {} nil (ring-handler handlers))))
 
-(defmacro middlewares
+(defmacro middleware
   "Wraps routes with given middlewares using thread-first macro."
-  [middlewares & body]
-  (let [middlewares (reverse middlewares)
+  [middleware & body]
+  (let [middleware (reverse middleware)
         routes? (> (count body) 1)]
     `(let [body# ~(if routes? `(routes ~@body) (first body))]
-       (routes/create "" nil {} [body#] (-> body# ~@middlewares)))))
+       (routes/create "" nil {} [body#] (-> body# ~@middleware)))))
 
 (defmacro context [& args] (meta/restructure nil      args {:routes 'routes}))
 

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -252,7 +252,7 @@
 ; Applies the given vector of middlewares to the route
 (defmethod restructure-param :middleware [_ middleware acc]
   (assert (and (vector? middleware) (every? #(or (and (vector? %1) (ifn? (first %1))) (ifn? %1)) middleware)))
-  (update-in acc [:middleware] into (reverse middleware)))
+  (update-in acc [:middleware] into middleware))
 
 ; Bind to stuff in request components using letk syntax
 (defmethod restructure-param :components [_ components acc]
@@ -300,7 +300,7 @@
     middleware))
 
 (defn compose-middleware [middleware]
-  (->> (reverse middleware)
+  (->> middleware
        (map middleware-fn)
        (apply comp identity)))
 

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -235,3 +235,20 @@
         wrap-keyword-params
         wrap-nested-params
         wrap-params)))
+
+(defn assert-middleware [middleware]
+  (assert (and (vector? middleware) (every? #(or (and (vector? %1) (ifn? (first %1))) (ifn? %1)) middleware))
+          (str "Middleware vector must only contain\n"
+               "a) fully configured middleware (function) or\n"
+               "b) vectors containing middleware function and additional parameters for it.")))
+
+(defn middleware-fn [middleware]
+  (if (vector? middleware)
+    (let [[f & arguments] middleware]
+      #(apply f % arguments))
+    middleware))
+
+(defn compose-middleware [middleware]
+  (->> middleware
+       (map middleware-fn)
+       (apply comp identity)))

--- a/src/compojure/api/sweet.clj
+++ b/src/compojure/api/sweet.clj
@@ -14,7 +14,7 @@
    defroutes
    let-routes
    undocumented
-   middlewares
+   middleware
 
    context
 

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -77,15 +77,15 @@
 ;; Facts
 ;;
 
-(facts "middlewares"
+(facts "middleware"
   (let [app (api
-              (middlewares [middleware* (middleware* 2)]
+              (middleware [middleware* (middleware* 2)]
                 (context "/middlewares" []
                   (GET "/simple" req (reply-mw* req))
-                  (middlewares [(middleware* 3) (middleware* 4)]
+                  (middleware [(middleware* 3) (middleware* 4)]
                     (GET "/nested" req (reply-mw* req))
                     (GET "/nested-declared" req
-                      :middlewares [(middleware* 5) (middleware* 6)]
+                      :middleware [(middleware* 5) (middleware* 6)]
                       (reply-mw* req))))))]
 
     (fact "are applied left-to-right"
@@ -103,12 +103,12 @@
         status => 200
         (get headers mw*) => "1234567654321"))))
 
-(facts "middlewares - multiple routes"
+(facts "middleware - multiple routes"
   (let [app (api
               (GET "/first" []
                 (ok {:value "first"}))
               (GET "/second" []
-                :middlewares [(constant-middleware (ok {:value "foo"}))]
+                :middleware [(constant-middleware (ok {:value "foo"}))]
                 (ok {:value "second"}))
               (GET "/third" []
                 (ok {:value "third"})))]
@@ -125,11 +125,11 @@
         status => 200
         body => {:value "third"}))))
 
-(facts "middlewares - editing request"
+(facts "middleware - editing request"
   (let [app (api
               (GET "/first" []
                 :query-params [x :- Long]
-                :middlewares [middleware-x]
+                :middleware [middleware-x]
                 (ok {:value x})))]
     (fact "middleware edits the parameter before route body"
       (let [[status body] (get* app "/first?x=5" {})]
@@ -515,12 +515,12 @@
           => #{:Urho :UrhoKaleva :UrhoKalevaKekkonen
                :Olipa :OlipaKerran :OlipaKerranAvaruus})))))
 
-(fact "swagger-docs works with the :middlewares"
+(fact "swagger-docs works with the :middleware"
   (let [app (api
               (swagger-docs)
               (GET "/middleware" []
                 :query-params [x :- String]
-                :middlewares [(constant-middleware (ok 1))]
+                :middleware [(constant-middleware (ok 1))]
                 (ok 2)))]
 
     (fact "api-docs"
@@ -1050,7 +1050,7 @@
 
 (fact "more swagger-data can be (deep-)merged in - either via swagger-docs at runtime via mws, fixes #170"
   (let [app (api
-              (middlewares [(rsm/wrap-swagger-data {:paths {"/runtime" {:get {}}}})]
+              (middleware [(rsm/wrap-swagger-data {:paths {"/runtime" {:get {}}}})]
                 (swagger-docs
                   {:info {:version "2.0.0"}
                    :paths {"/extra" {:get {}}}})

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -1125,3 +1125,13 @@
 
     (fact "throwing exceptions"
       (api {:api {:invalid-routes-fn routes/fail-on-invalid-child-routes}} invalid-routes)) => throws))
+
+(fact "old middleware format"
+  (macroexpand '(middleware [(middleware* 5)]
+                            (GET "/normal" [] (ok))))
+  => (throws AssertionError)
+
+  (macroexpand '(GET "/normal" []
+                  :middleware [(middleware* 5)]
+                  (ok)))
+  => (throws AssertionError))

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -79,13 +79,13 @@
 
 (facts "middleware"
   (let [app (api
-              (middleware [middleware* (middleware* 2)]
+              (middleware [middleware* [middleware* 2]]
                 (context "/middlewares" []
                   (GET "/simple" req (reply-mw* req))
-                  (middleware [(middleware* 3) (middleware* 4)]
+                  (middleware [[middleware* 3] [middleware* 4]]
                     (GET "/nested" req (reply-mw* req))
                     (GET "/nested-declared" req
-                      :middleware [(middleware* 5) (middleware* 6)]
+                      :middleware [[middleware* 5] [middleware* 6]]
                       (reply-mw* req))))))]
 
     (fact "are applied left-to-right"
@@ -108,7 +108,7 @@
               (GET "/first" []
                 (ok {:value "first"}))
               (GET "/second" []
-                :middleware [(constant-middleware (ok {:value "foo"}))]
+                :middleware [[constant-middleware (ok {:value "foo"})]]
                 (ok {:value "second"}))
               (GET "/third" []
                 (ok {:value "third"})))]
@@ -520,7 +520,7 @@
               (swagger-docs)
               (GET "/middleware" []
                 :query-params [x :- String]
-                :middleware [(constant-middleware (ok 1))]
+                :middleware [[constant-middleware (ok 1)]]
                 (ok 2)))]
 
     (fact "api-docs"
@@ -1050,7 +1050,7 @@
 
 (fact "more swagger-data can be (deep-)merged in - either via swagger-docs at runtime via mws, fixes #170"
   (let [app (api
-              (middleware [(rsm/wrap-swagger-data {:paths {"/runtime" {:get {}}}})]
+              (middleware [[rsm/wrap-swagger-data {:paths {"/runtime" {:get {}}}}]]
                 (swagger-docs
                   {:info {:version "2.0.0"}
                    :paths {"/extra" {:get {}}}})

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -36,16 +36,18 @@
 
 (defn middleware*
   "This middleware appends given value or 1 to a header in request and response."
-  [handler & [value]]
-  (fn [request]
-    (let [append #(str % (or value 1))
-          request (update-in request [:headers mw*] append)
-          response (handler request)]
-      (update-in response [:headers mw*] append))))
+  ([handler] (middleware* handler 1))
+  ([handler value]
+   (fn [request]
+     (let [append #(str % value)
+           request (update-in request [:headers mw*] append)
+           response (handler request)]
+       (update-in response [:headers mw*] append)))))
 
 (defn constant-middleware
   "This middleware rewrites all responses with a constant response."
-  [_ & [res]] (constantly res))
+  [_ res]
+  (constantly res))
 
 (defn reply-mw*
   "Handler which replies with response where a header contains copy

--- a/test/compojure/api/routes_test.clj
+++ b/test/compojure/api/routes_test.clj
@@ -30,7 +30,7 @@
   (#'routes/string-path-parameters "/:foo.json") => {:foo String})
 
 (facts "nested routes"
-  (let [middleware (fn [handler] (fn [request] (handler request)))
+  (let [mw (fn [handler] (fn [request] (handler request)))
         more-routes (fn [version]
                       (routes
                         (GET "/more" []
@@ -41,7 +41,7 @@
                    (ok {:message (str "pong - " version)}))
                  (POST "/ping" []
                    (ok {:message (str "pong - " version)}))
-                 (middlewares [middleware]
+                 (middleware [mw]
                    (GET "/hello" []
                      :return {:message String}
                      :summary "cool ping"


### PR DESCRIPTION
Should be quite clear except for where to put the middleware functions.

Now they reside in `compojure.api.middleware` namespace which makes sense per naming, but the namespace used to contain only middlewares. Perhaps `common` namespace would be good fit for these functions?

I wonder if we should remove `middleware` macro when breaking stuff, I don't think there is any use case for it?