### PR TITLE
Swagger routes basepath

### DIFF
--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -109,7 +109,7 @@
    (if options
      (let [{:keys [ui spec data] {ui-options :ui spec-options :spec} :options} (merge swagger-defaults options)]
        (c/routes
-         (if ui (apply swagger-ui ui (mapcat identity (merge ui-options (if spec {:swagger-docs spec})))))
+         (if ui (apply swagger-ui ui (mapcat identity (merge (if spec {:swagger-docs (apply str (remove clojure.string/blank? [(:basePath data) spec]))}) ui-options))))
          (if spec (apply swagger-docs spec (mapcat identity data))))))))
 
 (defn validate

--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -94,7 +94,8 @@
      :spec \"/swagger.json\"
      :options {:ui {:jsonEditor true}
                :spec {}}
-     :data {:info {:version \"1.0.0\"
+     :data {:basePath \"/app\"
+            :info {:version \"1.0.0\"
                    :title \"Sausages\"
                    :description \"Sausage description\"
                    :termsOfService \"http://helloreverb.com/terms/\"

--- a/test/compojure/api/swagger_test.clj
+++ b/test/compojure/api/swagger_test.clj
@@ -170,3 +170,18 @@
       :path-params [foo :- String]
       identity))
   => {"/:foo.json" {:get {:parameters {:path {:foo String}}}}})
+
+(facts
+  (tabular
+    (fact "swagger-routes basePath can be changed"
+      (let [app (api (swagger-routes ?given-options))]
+        (->
+          (get* app "/swagger.json")
+          (nth 1)
+          :basePath)
+        => ?expected-base-path
+        (nth (raw-get* app "/conf.js") 1) => (str "window.API_CONF = {\"url\":\"" ?expected-swagger-docs-path "\"};")))
+    ?given-options ?expected-swagger-docs-path ?expected-base-path
+    {} "/swagger.json" "/"
+    {:data {:basePath "/app"}} "/app/swagger.json" "/app"
+    {:data {:basePath "/app"} :options {:ui {:swagger-docs "/imaginary.json"}}} "/imaginary.json" "/app"))


### PR DESCRIPTION
 Teach swagger-routes to heed basePath for swagger-docs path

If {:data {:basePath "/app"}} is given, default to including it as a
prefix to swagger-ui :swagger-docs path. The basePath is already passed
to swagger-docs, so this makes the swagger-ui consistent with the
generated json.

The swagger-docs path can also now be completely overridden via:
{:options {:ui {:swagger-docs "/override.json"}}}