### PR TITLE
Include response when throwing on failed coercion

### DIFF
--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -63,7 +63,8 @@
                   coerce (coercer schema matcher)
                   body (coerce (:body response))]
               (if (su/error? body)
-                (throw (ex-info "Response validation error" (assoc body :type ::ex/response-validation)))
+                (throw (ex-info "Response validation error" (assoc body :type ::ex/response-validation
+                                                                        :response response)))
                 (assoc response
                   ::serializable? true
                   :body body)))


### PR DESCRIPTION
The purpose of this change is to give custom exception handlers access to the planned response when a response body can't be coerced to the correct output schema.

The specific use case I've got in mind is that when response coercion fails, I'd like to log the body that my controller code was trying to return - without this I only have access to the schema-failure error messages, which can be a little opaque. I was originally planning to return just the body here, but having the entire response structure seems like it could be helpful in some cases (maybe for looking at returned content-type headers etc).