### PR TITLE
Small fixes (1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,24 @@
 
 * Strip nils from `:middleware`, fixes [#228](https://github.com/metosin/compojure-api/issues/228)
 * Lazily require `ring.swagger.validator` namespace in `compojure.api.swagger/validate` to allow compojure-api apps in [Google App Engine](https://cloud.google.com/appengine), Fixes [#227](https://github.com/metosin/compojure-api/issues/227). **NOTE** exluding `metosin/scjsv` will cause the validate to fail at runtime.
-* Resources now implement `compojure.response/Renderable`, so that they can be used with endpoint macros like `ANY`
 * **BREAKING**: If a resource doesn't define a handler for a given `request-method` or for top-level, nil is returned (instead of throwing exeption)
+* Resource-routing is done with `context`. Trying to return a `compojure.api.routing/Route` from an endpoint like `ANY` will throw descriptive (runtime-)exception.
 
+```clj
+(context "/hello" []
+  (resource
+    {:description "hello-resource"
+     :responses {200 {:schema {:message s/Str}}}
+     :post {:summary "post-hello"
+            :parameters {:body-params {:name s/Str}}
+            :handler (fnk [[:body-params name]]
+                       (ok {:message (format "hello, %s!" name)}))}
+     :get {:summary "get-hello"
+           :parameters {:query-params {:name s/Str}}
+           :handler (fnk [[:query-params name]]
+                      (ok {:message (format "hello, %s!" name)}))}}))
 ```
+
 [metosin/compojure-api "1.0.3" :exclusions [[metosin/scjsv]]]
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 * api-level swagger-options default to `{:ui nil, :spec nil}`. Setting up just the spec or ui, doesn't automatically setup the other (like previously)
 * Strip nils from `:middleware`, fixes [#228](https://github.com/metosin/compojure-api/issues/228)
+* `describe` works with anonymous body-schemas (via ring-swagger `0.22.7`), Fixes [#168](https://github.com/metosin/compojure-api/issues/168)
 * Support compojure-api apps in [Google App Engine](https://cloud.google.com/appengine) by allowing [scjsv](https://github.com/metosin/scjsv) to be excluded (uses [json-schema-validator](https://github.com/fge/json-schema-validator), which uses rogue threads):
 
 ```clj

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 1.0.3-SNAPSHOT
+## 1.1.0-SNAPSHOT
 
 * Strip nils from `:middleware`, fixes [#228](https://github.com/metosin/compojure-api/issues/228)
 * Lazily require `ring.swagger.validator` namespace in `compojure.api.swagger/validate` to allow compojure-api apps in [Google App Engine](https://cloud.google.com/appengine), Fixes [#227](https://github.com/metosin/compojure-api/issues/227). **NOTE** exluding `metosin/scjsv` will cause the validate to fail at runtime.
 * Resources now implement `compojure.response/Renderable`, so that they can be used with endpoint macros like `ANY`
+* **BREAKING**: If a resource doesn't define a handler for a given `request-method` or for top-level, nil is returned (instead of throwing exeption)
 
 ```
 [metosin/compojure-api "1.0.3" :exclusions [[metosin/scjsv]]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 * updated dependencies:
 
 ```clj
+[metosin/ring-swagger "0.22.7"] is available but we use "0.22.6"
 [prismatic/plumbing "0.5.3"] is available but we use "0.5.2"
 [cheshire "5.6.1"] is available but we use "5.5.0"
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Strip nils from `:middleware`, fixes [#228](https://github.com/metosin/compojure-api/issues/228)
 * Lazily require `ring.swagger.validator` namespace in `compojure.api.swagger/validate` to allow compojure-api apps in [Google App Engine](https://cloud.google.com/appengine), Fixes [#227](https://github.com/metosin/compojure-api/issues/227). **NOTE** exluding `metosin/scjsv` will cause the validate to fail at runtime.
+* Resources now implement `compojure.response/Renderable`, so that they can be used with endpoint macros like `ANY`
 
 ```
 [metosin/compojure-api "1.0.3" :exclusions [[metosin/scjsv]]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## 1.1.0-SNAPSHOT
 
-* Strip nils from `:middleware`, fixes [#228](https://github.com/metosin/compojure-api/issues/228)
-* Lazily require `ring.swagger.validator` namespace in `compojure.api.swagger/validate` to allow compojure-api apps in [Google App Engine](https://cloud.google.com/appengine), Fixes [#227](https://github.com/metosin/compojure-api/issues/227). **NOTE** exluding `metosin/scjsv` will cause the validate to fail at runtime.
-* **BREAKING**: If a resource doesn't define a handler for a given `request-method` or for top-level, nil is returned (instead of throwing exeption)
-* Resource-routing is done with `context`. Trying to return a `compojure.api.routing/Route` from an endpoint like `ANY` will throw descriptive (runtime-)exception.
+* **BREAKING**: Move `compojure.api.swgger/validate` to `compojure.api.validator/validate`.
+* **BREAKING**: If a `resource` doesn't define a handler for a given `request-method` or for top-level, nil is returned (instead of throwing exeption)
+* **BREAKING** Resource-routing is done by `context`. Trying to return a `compojure.api.routing/Route` from an endpoint like `ANY` will throw descriptive (runtime-)exception.
 
 ```clj
 (context "/hello" []
@@ -18,9 +17,13 @@
            :parameters {:query-params {:name s/Str}}
            :handler (fnk [[:query-params name]]
                       (ok {:message (format "hello, %s!" name)}))}}))
-```
 
-[metosin/compojure-api "1.0.3" :exclusions [[metosin/scjsv]]]
+* api-level swagger-options default to `{:ui nil, :spec nil}`. Setting up just the spec or ui, doesn't automatically setup the other (like previously)
+* Strip nils from `:middleware`, fixes [#228](https://github.com/metosin/compojure-api/issues/228)
+* Support compojure-api apps in [Google App Engine](https://cloud.google.com/appengine) by allowing [scjsv](https://github.com/metosin/scjsv) to be excluded (uses [json-schema-validator](https://github.com/fge/json-schema-validator), which uses rogue threads):
+
+```clj
+[metosin/compojure-api "1.1.0" :exclusions [[metosin/scjsv]]]
 ```
 
 * updated dependencies:

--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [frankiesardo/linked "1.2.6"]
                  [ring-middleware-format "0.7.0"]
                  [metosin/ring-http-response "0.6.5"]
-                 [metosin/ring-swagger "0.22.6"]
+                 [metosin/ring-swagger "0.22.7"]
                  [metosin/ring-swagger-ui "2.1.4-0"]]
   :profiles {:uberjar {:aot :all
                        :ring {:handler examples.thingie/app}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject metosin/compojure-api "1.0.3-SNAPSHOT"
+(defproject metosin/compojure-api "1.1.0-SNAPSHOT"
   :description "Compojure Api"
   :url "https://github.com/metosin/compojure-api"
   :license {:name "Eclipse Public License"

--- a/src/compojure/api/api.clj
+++ b/src/compojure/api/api.clj
@@ -12,7 +12,7 @@
   (merge
     middleware/api-middleware-defaults
     {:api {:invalid-routes-fn routes/log-invalid-child-routes}
-     :swagger nil}))
+     :swagger {:ui nil, :spec nil}}))
 
 (defn
   ^{:doc (str

--- a/src/compojure/api/core.clj
+++ b/src/compojure/api/core.clj
@@ -4,17 +4,14 @@
             [compojure.api.middleware :as mw]
             [clojure.tools.macro :as macro]))
 
-(defn- ring-handler [handlers]
-  (condp = (count handlers)
-    0 (constantly nil)
-    1 (first handlers)
-    (fn [request] (some #(% request) handlers))))
+(defn- handle [handlers request]
+  (some #(% request) handlers))
 
 (defn routes
   "Create a Ring handler by combining several handlers into one."
   [& handlers]
-  (if-let [handlers (seq (keep identity handlers))]
-    (routes/create nil nil {} (vec handlers) (ring-handler handlers))))
+  (let [handlers (seq (keep identity handlers))]
+    (routes/create nil nil {} (vec handlers) (partial handle handlers))))
 
 (defmacro defroutes
   "Define a Ring handler function from a sequence of routes.
@@ -37,7 +34,7 @@
   not satisfying compojure.api.routes/Routing -protocol."
   [& handlers]
   (let [handlers (keep identity handlers)]
-    (routes/create nil nil {} nil (ring-handler handlers))))
+    (routes/create nil nil {} nil (partial handle handlers))))
 
 (defmacro middleware
   "Wraps routes with given middlewares using thread-first macro.

--- a/src/compojure/api/routes.clj
+++ b/src/compojure/api/routes.clj
@@ -42,7 +42,10 @@
   ([handler]
    (get-routes handler nil))
   ([handler options]
-   (-get-routes handler options)))
+   (mapv
+     (fn [route]
+       (update-in route [0] (fn [uri] (if (str/blank? uri) "/" uri))))
+     (-get-routes handler options))))
 
 (defrecord Route [path method info childs handler]
   Routing
@@ -50,7 +53,7 @@
     (let [valid-childs (filter-routes this options)]
       (if (seq childs)
         (vec
-          (for [[p m i] (mapcat #(get-routes % options) valid-childs)]
+          (for [[p m i] (mapcat #(-get-routes % options) valid-childs)]
             [(->paths path p) m (rsc/deep-merge info i)]))
         (into [] (if path [[path method info]])))))
 

--- a/src/compojure/api/routes.clj
+++ b/src/compojure/api/routes.clj
@@ -8,6 +8,7 @@
             [ring.swagger.common :as rsc]
             [clojure.string :as str]
             [linked.core :as linked]
+            [compojure.response]
             [schema.core :as s])
   (:import [clojure.lang AFn IFn Var]))
 
@@ -52,6 +53,9 @@
           (for [[p m i] (mapcat #(get-routes % options) valid-childs)]
             [(->paths path p) m (rsc/deep-merge info i)]))
         (into [] (if path [[path method info]])))))
+
+  compojure.response/Renderable
+  (render [_ request] (compojure.response/render (handler request) request))
 
   IFn
   (invoke [_ request]

--- a/src/compojure/api/routes.clj
+++ b/src/compojure/api/routes.clj
@@ -55,7 +55,16 @@
         (into [] (if path [[path method info]])))))
 
   compojure.response/Renderable
-  (render [_ request] (compojure.response/render (handler request) request))
+  (render [_ {:keys [uri request-method]}]
+    (throw
+      (ex-info
+        (str "\ncompojure.api.routes/Route can't be returned from endpoint "
+             (-> request-method name str/upper-case) " \"" uri "\". "
+             "For nested routes, use `context` instead: (context \"path\" []  ...)\n")
+        {:request-method request-method
+         :path path
+         :method method
+         :uri uri})))
 
   IFn
   (invoke [_ request]

--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -11,22 +11,6 @@
             [compojure.api.routes :as routes]
             [cheshire.core :as cheshire]))
 
-#_(defn ensure-parameter-schema-names [endpoint]
-    (if (get-in endpoint [:parameters :body])
-      (update-in endpoint [:parameters :body] #(swagger/with-named-sub-schemas % "Body"))
-      endpoint))
-
-#_(defn ensure-return-schema-names [endpoint]
-    (if (get-in endpoint [:responses])
-      (update-in
-        endpoint [:responses]
-        (fn [responses]
-          (into {} (map
-                     (fn [[k v]]
-                       [k (update-in v [:schema] swagger/with-named-sub-schemas "Response")])
-                     responses))))
-      endpoint))
-
 (defn base-path [request]
   (let [context (swagger/context request)]
     (if (= "" context) "/" context)))

--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -90,8 +90,8 @@
             :tags [{:name \"sausages\", :description \"Sausage api-set\"}]}}"
   ([] (swagger-routes {}))
   ([options]
-   (if options
-     (let [{:keys [ui spec data] {ui-options :ui spec-options :spec} :options} (merge swagger-defaults options)]
+   (let [{:keys [ui spec data] {ui-options :ui} :options} (merge swagger-defaults options)]
+     (if (or ui spec)
        (c/routes
          (if ui (apply swagger-ui ui (mapcat identity (merge (if spec {:swagger-docs (apply str (remove clojure.string/blank? [(:basePath data) spec]))}) ui-options))))
          (if spec (apply swagger-docs spec (mapcat identity data))))))))

--- a/src/compojure/api/validator.clj
+++ b/src/compojure/api/validator.clj
@@ -1,0 +1,28 @@
+(ns compojure.api.validator
+  (:require [compojure.api.swagger :as swagger]
+            [cheshire.core :as cheshire]
+            [ring.swagger.validator :as rsv]
+            [compojure.api.middleware :as mw]))
+
+(defn validate
+  "Validates a api. If the api is Swagger-enabled, the swagger-spec
+  is requested and validated against the JSON Schema. Returns either
+  the (valid) api or throws an exception. Requires lazily the
+  ring.swagger.validator -namespace allowing it to be excluded, #227"
+  [api]
+  (when-let [uri (swagger/swagger-spec-path api)]
+    (let [{status :status :as response} (api {:request-method :get
+                                              :uri uri
+                                              mw/rethrow-exceptions? true})
+          body (-> response :body slurp (cheshire/parse-string true))]
+
+      (when-not (= status 200)
+        (throw (ex-info (str "Coudn't read swagger spec from " uri)
+                        {:status status
+                         :body body})))
+
+      (when-let [errors (seq (rsv/validate body))]
+        (throw (ex-info (str "Invalid swagger spec from " uri)
+                        {:errors errors
+                         :body body})))))
+  api)

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -10,6 +10,7 @@
             [ring.util.http-status :as status]
             [compojure.api.middleware :as mw]
             [ring.swagger.middleware :as rsm]
+            [compojure.api.validator :as validator]
             [compojure.api.routes :as routes]))
 
 ;;
@@ -463,7 +464,85 @@
                          :consumes ["application/json" "application/edn"]
                          :produces ["application/json" "application/edn"]
                          :definitions {}
-                         :paths {"/user" {:get {:responses {:default {:description ""}}}}}})))
+                         :paths {"/user" {:get {:responses {:default {:description ""}}}}}}))
+
+  (fact "swagger-routes"
+
+    (fact "with defaults"
+      (let [app (api (swagger-routes))]
+
+        (fact "api-docs are mounted to /"
+          (let [[status body] (raw-get* app "/")]
+            status => 200
+            body => #"<title>Swagger UI</title>"))
+
+        (fact "spec is mounted to /swagger.json"
+          (let [[status body] (get* app "/swagger.json")]
+            status => 200
+            body => (contains {:swagger "2.0"})))))
+
+    (fact "with partial overridden values"
+      (let [app (api (swagger-routes {:ui "/api-docs"}))]
+
+        (fact "api-docs are mounted"
+          (let [[status body] (raw-get* app "/api-docs")]
+            status => 200
+            body => #"<title>Swagger UI</title>"))
+
+        (fact "spec is mounted to /swagger.json"
+          (let [[status body] (get* app "/swagger.json")]
+            status => 200
+            body => (contains {:swagger "2.0"}))))))
+
+  (fact "swagger via api-options"
+
+    (fact "with defaults"
+      (let [app (api)]
+
+        (fact "api-docs are not mounted"
+          (let [[status body] (raw-get* app "/")]
+            status => nil))
+
+        (fact "spec is not mounted"
+          (let [[status body] (get* app "/swagger.json")]
+            status => nil))))
+
+    (fact "with spec"
+      (let [app (api {:swagger {:spec "/swagger.json"}})]
+
+        (fact "api-docs are not mounted"
+          (let [[status body] (raw-get* app "/")]
+            status => nil))
+
+        (fact "spec is mounted to /swagger.json"
+          (let [[status body] (get* app "/swagger.json")]
+            status => 200
+            body => (contains {:swagger "2.0"}))))))
+
+  (fact "with ui"
+    (let [app (api {:swagger {:ui "/api-docs"}})]
+
+      (fact "api-docs are mounted"
+        (let [[status body] (raw-get* app "/api-docs")]
+          status => 200
+          body => #"<title>Swagger UI</title>"))
+
+      (fact "spec is not mounted"
+        (let [[status body] (get* app "/swagger.json")]
+          status => nil))))
+
+  (fact "with ui and spec"
+    (let [app (api {:swagger {:spec "/swagger.json", :ui "/api-docs"}})]
+
+      (fact "api-docs are mounted"
+        (let [[status body] (raw-get* app "/api-docs")]
+          status => 200
+          body => #"<title>Swagger UI</title>"))
+
+      (fact "spec is mounted to /swagger.json"
+        (let [[status body] (get* app "/swagger.json")]
+          status => 200
+          body => (contains {:swagger "2.0"}))))))
 
 (facts "swagger-docs with anonymous Return and Body models"
   (let [app (api
@@ -971,7 +1050,7 @@
           body => {:data "ping"}))
 
       (fact "the api is valid"
-        (swagger/validate app) => app)))
+        (validator/validate app) => app)))
 
   (fact "a swagger api with invalid swagger records"
     (let [app (api
@@ -986,7 +1065,7 @@
           body => {:data "ping"}))
 
       (fact "the api is invalid"
-        (swagger/validate app)
+        (validator/validate app)
         => (throws
              IllegalArgumentException
              (str
@@ -1005,7 +1084,7 @@
           body => {:data "ping"}))
 
       (fact "the api is valid"
-        (swagger/validate app) => app))))
+        (validator/validate app) => app))))
 
 (fact "component integration"
   (let [system {:magic 42}]
@@ -1191,7 +1270,8 @@
 (fact "using local symbols for restructuring params"
   (let [responses {400 {:schema {:fail s/Str}}}
         app (api
-              {:swagger {:data {:info {:version "2.0.0"}}}}
+              {:swagger {:spec "/swagger.json"
+                         :data {:info {:version "2.0.0"}}}}
               (GET "/a" []
                 :responses responses
                 :return {:ok s/Str}

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -1364,3 +1364,13 @@
         body => {:kikka "kukka"}))
     (fact "swagger docs"
       (-> app get-spec :paths keys) => ["/"])))
+
+(fact "describe works on anonymous bodys, #168"
+  (let [app (api
+              (swagger-routes)
+              (POST "/" []
+                :body [body (describe {:kikka [{:kukka String}]} "kikkas")]
+                (ok body)))]
+    (fact "description is in place"
+      (-> app get-spec :paths (get "/") :post :parameters first )
+      => (contains {:description "kikkas"}))))

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -1274,3 +1274,13 @@
     (fact "swagger parameters are in correct order"
       (-> app get-spec :paths (get "/ping") :get :parameters (->> (map (comp keyword :name)))) => [:a :b :c :d :e])))
 
+(fact "empty top-level route, #https://github.com/metosin/ring-swagger/issues/92"
+  (let [app (api
+              {:swagger {:spec "/swagger.json"}}
+              (GET "/" [] (ok {:kikka "kukka"})))]
+    (fact "api works"
+      (let [[status body] (get* app "/")]
+        status => 200
+        body => {:kikka "kukka"}))
+    (fact "swagger docs"
+      (-> app get-spec :paths keys) => ["/"])))

--- a/test/compojure/api/resource_test.clj
+++ b/test/compojure/api/resource_test.clj
@@ -113,35 +113,29 @@
                   (GET "/no" request
                     (ok (select-keys request [:uri :path-info])))
 
-                  (ANY "/any" []
-                    (resource
-                      {:handler (constantly (ok "ANY"))}))
-
                   (context "/context" []
                     (resource
                       {:handler (constantly (ok "CONTEXT"))}))
 
-                  (GET "/get" []
+                  ;; does not work
+                  (ANY "/any" []
                     (resource
-                      {:post {:handler (constantly (ok "GET"))}}))
+                      {:handler (constantly (ok "ANY"))}))
 
                   (resource
                     {:get {:handler (fn [request]
                                       (ok (select-keys request [:uri :path-info])))}}))]
 
-    (fact "normal endpoint"
+    (fact "normal endpoint works"
       (handler {:request-method :get, :uri "/rest/no"}) => (has-body {:uri "/rest/no", :path-info "/no"}))
 
-    (fact "wrapped in ANY"
-      (handler {:request-method :get, :uri "/rest/any"}) => (has-body "ANY"))
+    (fact "wrapped in ANY fails at runtime"
+      (handler {:request-method :get, :uri "/rest/any"}) => throws)
 
-    (fact "wrapped in context"
+    (fact "wrapped in context works"
       (handler {:request-method :get, :uri "/rest/context"}) => (has-body "CONTEXT"))
 
-    (fact "impossible route"
-      (handler {:request-method :get, :uri "/rest/get"}) => (has-body {:uri "/rest/get", :path-info "/get"}))
-
-    (fact "top-level GET hits"
+    (fact "top-level GET works"
       (handler {:request-method :get, :uri "/rest/in-peaces"}) => (has-body {:uri "/rest/in-peaces"
                                                                              :path-info "/in-peaces"}))
 


### PR DESCRIPTION
* **BREAKING**: Move `compojure.api.swgger/validate` to `compojure.api.validator/validate`.
* **BREAKING**: If a `resource` doesn't define a handler for a given `request-method` or for top-level, nil is returned (instead of throwing exeption)
* **BREAKING** Resource-routing is done by `context`. Trying to return a `compojure.api.routing/Route` from an endpoint like `ANY` will throw descriptive (runtime-)exception.

```clj
(context "/hello" []
  (resource
    {:description "hello-resource"
     :responses {200 {:schema {:message s/Str}}}
     :post {:summary "post-hello"
            :parameters {:body-params {:name s/Str}}
            :handler (fnk [[:body-params name]]
                       (ok {:message (format "hello, %s!" name)}))}
     :get {:summary "get-hello"
           :parameters {:query-params {:name s/Str}}
           :handler (fnk [[:query-params name]]
                      (ok {:message (format "hello, %s!" name)}))}}))
```

* api-level swagger-options default to `{:ui nil, :spec nil}`. Setting up just the spec or ui, doesn't automatically setup the other (like previously)
* Strip nils from `:middleware`, fixes [#228](https://github.com/metosin/compojure-api/issues/228)
* Support compojure-api apps in [Google App Engine](https://cloud.google.com/appengine) by allowing [scjsv](https://github.com/metosin/scjsv) to be excluded (uses [json-schema-validator](https://github.com/fge/json-schema-validator), which uses rogue threads):

```clj
[metosin/compojure-api "1.1.0" :exclusions [[metosin/scjsv]]]
```