### PR TITLE
Add option to look at the user'a handler before swagger-ui handler

### DIFF
--- a/src/compojure/api/api.clj
+++ b/src/compojure/api/api.clj
@@ -43,6 +43,21 @@
   - **:swagger**                   Options to configure the Swagger-routes. Defaults to nil.
                                    See `compojure.api.swagger/swagger-routes` for details.
 
+  - **:handler-wont-404**          Normally, api checks URIs for swagger-ui routes before
+                                   delegating to your supplied handler. This is necessary because
+                                   otherwise, swagger-ui requests would pass through your handler,
+                                   finding no match, and your handler would return a 404, meaning
+                                   that compojure would never check the swagger-ui routes.
+                                   You can slightly improve performance of your api routes if you
+                                   promise that your routes will not return a 404 for paths you
+                                   don't recognize, for example in a setup like:
+
+                                   (-> (api {:handler-wont-404 true} (GET ...))
+                                       (routes (constantly {:status 404 :body \"Not found\"})))
+
+                                   If you do, api will check your routes for matches before looking
+                                   for a matching swagger-ui route.
+
   ### api-middleware options
 
   " (:doc (meta #'compojure.api.middleware/api-middleware)))}
@@ -50,7 +65,10 @@
   [& body]
   (let [[options handlers] (common/extract-parameters body false)
         options (rsc/deep-merge api-defaults options)
-        handler (apply c/routes (concat [(swagger/swagger-routes (:swagger options))] handlers))
+        handler (apply c/routes
+                       (if (:handler-wont-404 options)
+                         (concat handlers [(swagger/swagger-routes (:swagger options))])
+                         (concat [(swagger/swagger-routes (:swagger options))] handlers)))
         routes (routes/get-routes handler (:api options))
         paths (-> routes routes/ring-swagger-paths swagger/transform-operations)
         lookup (routes/route-lookup-table routes)

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -1176,25 +1176,35 @@
                             :type "boolean"}]})))))
 
 (fact "swagger-docs via api options, #218"
-  (let [routes (routes
-                 (context "/api" []
-                   (GET "/ping" []
-                     :summary "ping"
-                     (ok {:message "pong"}))
-                   (POST "/pong" []
-                     :summary "pong"
-                     (ok {:message "ping"})))
-                 (ANY "*" []
-                   (ok {:message "404"})))
-        api1 (api {:swagger {:spec "/swagger.json", :ui "/"}} routes)
-        api2 (api (swagger-routes) routes)]
+  (let [without-404 (context "/api" []
+                      (GET "/ping" []
+                        :summary "ping"
+                        (ok {:message "pong"}))
+                      (POST "/pong" []
+                        :summary "pong"
+                        (ok {:message "ping"})))
+        not-found-handler (ANY "*" []
+                            (ok {:message "404"}))
+        swagger-opts {:swagger {:spec "/swagger.json", :ui "/"}}
+        handler (routes without-404 not-found-handler)
+        api1 (api swagger-opts handler)
+        api2 (api (swagger-routes) handler)
+        api3 (routes (api (assoc swagger-opts :handler-wont-404 true)
+                          without-404)
+                     not-found-handler)]
 
     (fact "both generate same swagger-spec"
       (get-spec api1) => (get-spec api2))
 
     (fact "not-found handler works"
       (second (get* api1 "/missed")) => {:message "404"}
-      (second (get* api2 "/missed")) => {:message "404"})))
+      (second (get* api2 "/missed")) => {:message "404"})
+
+    (fact ":handler-wont-404 works"
+      (get-spec api3) => (-> (get-spec api1)
+                             (update :paths dissoc "/*"))
+      (second (get* api3 "/api/ping")) => {:message "pong"}
+      (second (get* api3 "/missed")) => {:message "404"})))
 
 (fact "more swagger-data can be (deep-)merged in - either via swagger-docs at runtime via mws, fixes #170"
   (let [app (api


### PR DESCRIPTION
The docs I added may be a bit too verbose - I wasn't sure how much "justification" of the feature belongs in the docstring vs in this pull request. Basically the idea is that it's ideal to consult the user's handler before consulting the swagger-ui handler, so that the user sees no performance penalty on performance-sensitive requests. But normally you can't do that, because the user's handler will return a 404 for routes it doesn't recognize, including swagger-ui routes.

So, I added a way to specifically say "my handler won't return a 404 for routes it doesn't recognize", meaning that it becomes safe to consult the user's handler first, then the swagger-ui routes, and then if *neither* of those matches, presume that the user has wrapped the entire `(api ...)` handler in some middleware that will produce 404 responses as necessary.

An alternative implementation that could resolve the issue differently would be to add a `not-found-handler` option to `api`, and insert that after both the user's handler and the swagger-ui handler. You still need to be sure that the user's handler doesn't return any 404s it shouldn't, but perhaps this is a more self-documenting way to explain how 404s will be handled.