### PR TITLE
Respect :content-type attribute of custom formats

### DIFF
--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -109,7 +109,7 @@
 ;; ring-middleware-format stuff
 ;;
 
-(def ^:private mime-types
+(def ^:private default-mime-types
   {:json "application/json"
    :json-kw "application/json"
    :edn "application/edn"
@@ -119,6 +119,11 @@
    :yaml-in-html "text/html"
    :transit-json "application/transit+json"
    :transit-msgpack "application/transit+msgpack"})
+
+(defn mime-types
+  [format]
+  (get default-mime-types format
+       (some-> format :content-type)))
 
 (def ^:private response-only-mimes #{:clojure :yaml-in-html})
 


### PR DESCRIPTION
# Context

When defining an `api` one is allowed to pass in a vector of formats the api supports.
At this point one may insert a custom format. A simple case might be a json format that also encodes a specific version:

```clojure
(def my-custom-format
  (format-response/make-encoder json/generate-string "application/vnd.vendor.v1+json"))

{:format  {:formats [my-custom-format :edn :json]}
 :swagger {...}]}}}
```

A format can be either a keyword form a supported set of formats or a custom format.
Custom formats are maps that contain various necessary values that can be used to produce a response string. The `:content-type` key is used to describe the custom format content type, usually in mime type format.

# Desired behaviour

The content type of custom formats should be part of the generated swagger document under the `produces` key.

Example:
```json
{
"swagger": "2.0",
"info": {...},
"produces": [
    "application/json",
    "application/vnd.vendor.v1+json"
],
"consumes": [...],
"basePath": "/",
"paths": {...},
"tags": [...],
"definitions": {...}
}
```

# Current behaviour 

At the moment the `produces` key ignores any custom formats.
Side note: Version 1.4x would show a nil for custom types.

# Change description

The current implementation uses a fixed map of keyword to string mappings for different standard formats like `:json` and `:edn`.
This pull request instead introduces a function that tries to lookup the given format in that map, when that fails it assumes that the format is a map that contains a `:content-type` key which points to a string which can serve as a value in the `produces` vector.