### PR TITLE
Fast contexts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: clojure
 lein: lein2
 script: lein2 do clean, all midje, all check
 jdk:
-  - openjdk6
   - openjdk7
   - oraclejdk8
 cache:

--- a/examples/thingie/src/examples/dates.clj
+++ b/examples/thingie/src/examples/dates.clj
@@ -2,8 +2,8 @@
   (:require [compojure.api.sweet :refer :all]
             [schema.core :as s]
             [ring.util.http-response :refer :all])
-  (:import [java.util Date]
-           [org.joda.time DateTime LocalDate]))
+  (:import (java.util Date)
+           (org.joda.time LocalDate DateTime)))
 
 (s/defschema Dates {:date Date
                     :date-time DateTime

--- a/examples/thingie/src/examples/thingie.clj
+++ b/examples/thingie/src/examples/thingie.clj
@@ -8,7 +8,7 @@
             [examples.pizza :refer [pizza-routes Pizza]]
             [examples.ordered :refer [ordered-routes]]
             [examples.dates :refer [date-routes]])
-  (:import [org.joda.time DateTime]))
+  (:import (org.joda.time DateTime)))
 
 ;;
 ;; Schemas
@@ -24,27 +24,28 @@
 
 (def app
   (api
-    {:swagger {:ui "/"
-               :spec "/swagger.json"
-               :data {:info {:version "1.0.0"
-                             :title "Thingies API"
-                             :description "the description"
-                             :termsOfService "http://www.metosin.fi"
-                             :contact {:name "My API Team"
-                                       :email "foo@example.com"
-                                       :url "http://www.metosin.fi"}
-                             :license {:name "Eclipse Public License"
-                                       :url "http://www.eclipse.org/legal/epl-v10.html"}}
-                      :tags [{:name "math", :description "Math with parameters"}
-                             {:name "pizzas", :description "Pizza API"}
-                             {:name "failing", :description "Handling uncaught exceptions"}
-                             {:name "dates", :description "Dates API"}
-                             {:name "responses", :description "Responses demo"}
-                             {:name "primitives", :description "Returning primitive values"}
-                             {:name "context", :description "context routes"}
-                             {:name "echo", :description "Echoes data"}
-                             {:name "ordered", :description "Ordered routes"}
-                             {:name "file", :description "File upload"}]}}}
+    {:swagger
+     {:ui "/"
+      :spec "/swagger.json"
+      :data {:info {:version "1.0.0"
+                    :title "Thingies API"
+                    :description "the description"
+                    :termsOfService "http://www.metosin.fi"
+                    :contact {:name "My API Team"
+                              :email "foo@example.com"
+                              :url "http://www.metosin.fi"}
+                    :license {:name "Eclipse Public License"
+                              :url "http://www.eclipse.org/legal/epl-v10.html"}}
+             :tags [{:name "math", :description "Math with parameters"}
+                    {:name "pizzas", :description "Pizza API"}
+                    {:name "failing", :description "Handling uncaught exceptions"}
+                    {:name "dates", :description "Dates API"}
+                    {:name "responses", :description "Responses demo"}
+                    {:name "primitives", :description "Returning primitive values"}
+                    {:name "context", :description "context routes"}
+                    {:name "echo", :description "Echoes data"}
+                    {:name "ordered", :description "Ordered routes"}
+                    {:name "file", :description "File upload"}]}}}
 
     (context "/math" []
       :tags ["math"]

--- a/project.clj
+++ b/project.clj
@@ -5,14 +5,16 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
-  :dependencies [[prismatic/plumbing "0.5.3"]
+  :dependencies [[ring "1.6.0-beta6"]
                  [potemkin "0.4.3"]
                  [cheshire "5.6.3"]
                  [compojure "1.5.1"]
                  [prismatic/schema "1.1.3"]
+                 [prismatic/plumbing "0.5.3"]
                  [org.tobereplaced/lettercase "1.0.0"]
                  [frankiesardo/linked "1.2.9"]
                  [ring-middleware-format "0.7.0"]
+                 [metosin/muuntaja "0.1.0-SNAPSHOT"]
                  [metosin/ring-http-response "0.8.0"]
                  [metosin/ring-swagger "0.22.11"]
                  [metosin/ring-swagger-ui "2.2.5-0"]]
@@ -43,7 +45,7 @@
                           :reload-paths ["src" "examples/thingie/src"]}
                    :source-paths ["examples/thingie/src" "examples/thingie/dev-src"]
                    :main examples.server}
-             :perf {:jvm-opts ^:replace []}
+             :perf {:jvm-opts ^:replace ["-server"]}
              :logging {:dependencies [[org.clojure/tools.logging "0.3.1"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}}
   :eastwood {:namespaces [:source-paths]

--- a/project.clj
+++ b/project.clj
@@ -44,7 +44,9 @@
                           :reload-paths ["src" "examples/thingie/src"]}
                    :source-paths ["examples/thingie/src" "examples/thingie/dev-src"]
                    :main examples.server}
-             :perf {:jvm-opts ^:replace ["-server"]}
+             :perf {:jvm-opts ^:replace ["-server"
+                                         "-Xmx4096m"
+                                         "-Dclojure.compiler.direct-linking=true"]}
              :logging {:dependencies [[org.clojure/tools.logging "0.3.1"]]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}}
   :eastwood {:namespaces [:source-paths]

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,6 @@
                  [prismatic/plumbing "0.5.3"]
                  [org.tobereplaced/lettercase "1.0.0"]
                  [frankiesardo/linked "1.2.9"]
-                 [ring-middleware-format "0.7.0"]
                  [metosin/muuntaja "0.1.0-SNAPSHOT"]
                  [metosin/ring-http-response "0.8.0"]
                  [metosin/ring-swagger "0.22.11"]

--- a/src/compojure/api/exception.clj
+++ b/src/compojure/api/exception.clj
@@ -50,12 +50,12 @@
 
 (defn request-parsing-handler
   [^Exception ex data req]
-  (let [cause (.getCause ex)]
-    (response/bad-request {:type (cond
-                                   (instance? JsonParseException cause) "json-parse-exception"
-                                   (instance? ParserException cause) "yaml-parse-exception"
-                                   :else "parse-exception")
-                           :message (.getMessage cause)})))
+  (let [cause (.getCause ex)
+        original (.getCause cause)]
+    (response/bad-request
+      (merge (select-keys data [:type :format :charset])
+             (if original {:original (.getMessage original)})
+             {:message (.getMessage cause)}))))
 
 ;;
 ;; Logging
@@ -75,5 +75,6 @@
 ;; Mappings from other Exception types to our base types
 ;;
 
-(def legacy-exception-types
-  {:ring.swagger.schema/validation ::request-validation})
+(def mapped-exception-types
+  {:ring.swagger.schema/validation ::request-validation
+   :muuntaja.core/decode ::request-parsing})

--- a/src/compojure/api/exception.clj
+++ b/src/compojure/api/exception.clj
@@ -3,9 +3,7 @@
             [clojure.walk :as walk]
             [compojure.api.impl.logging :as logging]
             [schema.utils :as su])
-  (:import [schema.utils ValidationError NamedError]
-           [com.fasterxml.jackson.core JsonParseException]
-           [org.yaml.snakeyaml.parser ParserException]))
+  (:import (schema.utils ValidationError NamedError)))
 
 ;;
 ;; Default exception handlers

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -271,9 +271,9 @@
           (seq responses) (assoc :responses (apply merge responses))
           swagger (-> (dissoc :swagger) (rsc/deep-merge swagger))))
 
-(defn restructure [method [path arg & args] {:keys [context?]}]
+(defn restructure [method [path route-arg & args] {:keys [context?]}]
   (let [[options body] (extract-parameters args true)
-        [path-string lets arg-with-request arg] (destructure-compojure-api-request path arg)
+        [path-string lets arg-with-request arg] (destructure-compojure-api-request path route-arg)
 
         {:keys [lets
                 letks

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -239,6 +239,11 @@
     `(do ~@body)
     (reverse (partition 2 bindings))))
 
+(defmacro static-context
+  [path route]
+  `(#'compojure.core/if-context
+     ~(#'compojure.core/context-route path)
+     ~route))
 ;;
 ;; Api
 ;;
@@ -271,6 +276,9 @@
           (seq responses) (assoc :responses (apply merge responses))
           swagger (-> (dissoc :swagger) (rsc/deep-merge swagger))))
 
+(defn- route-args? [arg]
+  (not= arg []))
+
 (defn restructure [method [path route-arg & args] {:keys [context?]}]
   (let [[options body] (extract-parameters args true)
         [path-string lets arg-with-request arg] (destructure-compojure-api-request path route-arg)
@@ -293,6 +301,8 @@
                           :body body}
                          options)
 
+        static? (not (or (route-args? route-arg) (seq lets) (seq letks)))
+
         ;; migration helpers
         _ (assert (not middlewares) ":middlewares is deprecated with 1.0.0, use :middleware instead.")
         _ (assert (not parameters) ":parameters is deprecated with 1.0.0, use :swagger instead.")
@@ -307,7 +317,9 @@
             form (if (seq letks) `(p/letk ~letks ~form) form)
             form (if (seq lets) `(let ~lets ~form) form)
             form (if (seq middleware) `((mw/compose-middleware ~middleware) ~form) form)
-            form `(compojure.core/context ~path ~arg-with-request ~form)
+            form (if static?
+                   `(static-context ~path ~form)
+                   `(compojure.core/context ~path ~arg-with-request ~form))
 
             ;; create and apply a separate lookup-function to find the inner routes
             childs (let [form (vec body)

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -166,7 +166,7 @@
 
   - **:formats**                   for Muuntaja middleware. Value can be a valid muuntaja options-map,
                                    a created Muuntaja or nil (to unmount it). See
-                                   https://github.com/metosin/muuntaja for details.
+                                   https://github.com/metosin/muuntaja/wiki/Configuration for details.
 
   - **:ring-swagger**              options for ring-swagger's swagger-json method.
                                    e.g. `{:ignore-missing-mappings? true}`

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -165,7 +165,7 @@
       - **:handlers**                Map of error handlers for different exception types, type refers to `:type` key in ExceptionInfo data.
 
   - **:formats**                   for Muuntaja middleware. Value can be a valid muuntaja options-map,
-                                   a created Muuntaja or nil (to unmount it). See
+                                   a Muuntaja instance or nil (to unmount it). See
                                    https://github.com/metosin/muuntaja/wiki/Configuration for details.
 
   - **:ring-swagger**              options for ring-swagger's swagger-json method.

--- a/src/compojure/api/routes.clj
+++ b/src/compojure/api/routes.clj
@@ -10,7 +10,7 @@
             [linked.core :as linked]
             [compojure.response]
             [schema.core :as s])
-  (:import [clojure.lang AFn IFn Var]))
+  (:import (clojure.lang AFn IFn Var)))
 
 ;;
 ;; Route records

--- a/test/compojure/api/compojure_perf_test.clj
+++ b/test/compojure/api/compojure_perf_test.clj
@@ -29,6 +29,8 @@
 
 (defn compojure-bench []
 
+  ;; 3.8µs
+  ;; 2.6µs
   (let [app (c/routes
               (c/GET "/a/b/c/1" [] "ok")
               (c/GET "/a/b/c/2" [] "ok")
@@ -42,8 +44,8 @@
     (assert (-> (call) :body (= "ok")))
     (cc/quick-bench (call)))
 
-  ;; 3.8µs
-
+  ;; 15.9µs
+  ;; 11.6µs
   (let [app (c/context "/a" []
               (c/context "/b" []
                 (c/context "/c" []
@@ -67,14 +69,12 @@
 
     (title "Compojure - GET with context")
     (assert (-> (call) :body (= "ok")))
-    (cc/quick-bench (call)))
-
-  ;; 15.9µs
-
-  )
+    (cc/quick-bench (call))))
 
 (defn compojure-api-bench []
 
+  ;; 3.8µs
+  ;; 2.7µs
   (let [app (s/routes
               (s/GET "/a/b/c/1" [] "ok")
               (s/GET "/a/b/c/2" [] "ok")
@@ -88,8 +88,8 @@
     (assert (-> (call) :body (= "ok")))
     (cc/quick-bench (call)))
 
-  ;; 3.8µs
-
+  ;; 20.0µs
+  ;; 17.0µs
   (let [app (s/context "/a" []
               (s/context "/b" []
                 (s/context "/c" []
@@ -113,10 +113,8 @@
 
     (title "Compojure API - GET with context")
     (assert (-> (call) :body (= "ok")))
-    (cc/quick-bench (call)))
+    (cc/quick-bench (call))))
 
-  ;; 20.0µs
-  )
 
 (defn bench []
   (compojure-bench)

--- a/test/compojure/api/compojure_perf_test.clj
+++ b/test/compojure/api/compojure_perf_test.clj
@@ -90,6 +90,7 @@
 
   ;; 20.0µs
   ;; 17.0µs
+  ;; 11.4µs static-context (-30%)
   (let [app (s/context "/a" []
               (s/context "/b" []
                 (s/context "/c" []
@@ -118,6 +119,7 @@
 (defn compojure-api-mw-bench []
 
   ;; 47.0µs (15 + 3906408 calls)
+  ;; 10.9µs (77 + 0 calls) - static-context (-75%)
   (let [calls (atom nil)
         mw (fn [handler x] (swap! calls update x (fnil inc 0)) (fn [req] (handler req)))
         app (s/context "/a" []

--- a/test/compojure/api/exception_test.clj
+++ b/test/compojure/api/exception_test.clj
@@ -2,7 +2,7 @@
   (:require [compojure.api.exception :refer :all]
             [midje.sweet :refer :all]
             [schema.core :as s])
-  (:import [schema.utils ValidationError NamedError]))
+  (:import (schema.utils ValidationError NamedError)))
 
 (fact "stringify-error"
   (fact "ValidationError"

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -12,8 +12,7 @@
             [ring.swagger.middleware :as rsm]
             [compojure.api.validator :as validator]
             [compojure.api.routes :as routes]
-            [cheshire.core :as json])
-  (:import (java.io ByteArrayInputStream)))
+            [cheshire.core :as json]))
 
 ;;
 ;; Data
@@ -484,8 +483,7 @@
 
 (fact "swagger-docs"
   (let [app (api
-              {:format {:formats [:json-kw :edn :UNKNOWN]}
-               :formats (muuntaja.core/with-formats
+              {:formats (muuntaja.core/with-formats
                           muuntaja.core/default-options
                           ["application/json" "application/edn"])}
               (swagger-routes)
@@ -1485,8 +1483,7 @@
               {:swagger {:spec "/swagger.json"}
                :formats (-> muuntaja.core/default-options
                             (update :formats assoc custom-type custom-format)
-                            (muuntaja.core/with-formats ["application/json" custom-type]))
-               :format {:formats [:json]}}
+                            (muuntaja.core/with-formats ["application/json" custom-type]))}
               (POST "/echo" []
                 :body [data {:kikka s/Str}]
                 (ok data)))]

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -12,6 +12,7 @@
             [ring.swagger.middleware :as rsm]
             [compojure.api.validator :as validator]
             [compojure.api.routes :as routes]
+            [muuntaja.options :as options]
             [cheshire.core :as json]))
 
 ;;
@@ -483,7 +484,7 @@
 
 (fact "swagger-docs"
   (let [app (api
-              {:formats (muuntaja.core/with-formats
+              {:formats (options/formats
                           muuntaja.core/default-options
                           ["application/json" "application/edn"])}
               (swagger-routes)
@@ -1483,7 +1484,7 @@
               {:swagger {:spec "/swagger.json"}
                :formats (-> muuntaja.core/default-options
                             (update :formats assoc custom-type custom-format)
-                            (muuntaja.core/with-formats ["application/json" custom-type]))}
+                            (options/formats ["application/json" custom-type]))}
               (POST "/echo" []
                 :body [data {:kikka s/Str}]
                 (ok data)))]

--- a/test/compojure/api/middleware_test.clj
+++ b/test/compojure/api/middleware_test.clj
@@ -21,11 +21,11 @@
        (finally
          (System/setErr err#)))))
 
-(facts serializable?
+(facts encode?
   (tabular
     (fact
-      (serializable? nil
-                     {:body ?body
+      (encode? nil
+               {:body ?body
                       :compojure.api.meta/serializable? ?serializable?}) => ?res)
     ?body ?serializable? ?res
     5 true true

--- a/test/compojure/api/middleware_test.clj
+++ b/test/compojure/api/middleware_test.clj
@@ -4,9 +4,9 @@
             [midje.sweet :refer :all]
             [ring.util.http-response :refer [ok]]
             [ring.util.http-status :as status]
-            ring.util.test
+            [ring.util.test]
             [slingshot.slingshot :refer [throw+]])
-  (:import [java.io PrintStream ByteArrayOutputStream]))
+  (:import (java.io PrintStream ByteArrayOutputStream)))
 
 (defmacro without-err
   "Evaluates exprs in a context in which *err* is bound to a fresh

--- a/test/compojure/api/perf_test.clj
+++ b/test/compojure/api/perf_test.clj
@@ -57,6 +57,7 @@
   ; 27µs
   ; 27µs (-0%)
   ; 25µs (1.0.0)
+  ; 25µs (muuntaja)
   (let [app (api
               (GET "/30" []
                 (ok {:result 30})))
@@ -69,6 +70,7 @@
   ;; 73µs
   ;; 53µs (-27%)
   ;; 50µs (1.0.0)
+  ;; 38µs (muuntaja), -24%
   (let [app (api
               (POST "/plus" []
                 :return {:result s/Int}
@@ -84,6 +86,7 @@
   ;; 85µs
   ;; 67µs (-21%)
   ;; 66µs (1.0.0)
+  ;; 56µs (muuntaja), -15%
   (let [app (api
               (context "/a" []
                 (context "/b" []
@@ -102,6 +105,7 @@
   ;; 266µs
   ;; 156µs (-41%)
   ;; 146µs (1.0.0)
+  ;;  74µs (muuntaja), -49%
   (let [app (api
               (POST "/echo" []
                 :return Order
@@ -132,6 +136,7 @@
                                         (ok {:result (+ x y)}))}}]
 
     ;; 62µs
+    ;; 44µs (muuntaja)
     (let [my-resource (resource resource-map)
           app (api
                 (context "/plus" []
@@ -144,6 +149,7 @@
       (cc/bench (call)))
 
     ;; 68µs
+    ;; 52µs (muuntaja)
     (let [app (api
                 (context "/plus" []
                   (resource resource-map)))
@@ -211,18 +217,23 @@
 
       "10b"
       ;; 42µs
+      ;; 24µs (muuntaja), -43%
 
       "100b"
       ;; 79µs
+      ;; 39µs (muuntaja), -50%
 
       "1k"
       ;; 367µs
+      ;;  92µs (muuntaja), -75%
 
       "10k"
       ;; 2870µs
+      ;; 837µs (muuntaja), -70%
 
       "100k"
       ;; 10800µs
+      ;;  8050µs (muuuntaja), -25%
 
       (title file)
       (cc/bench (-> (request!) app :body slurp)))))

--- a/test/compojure/api/perf_test.clj
+++ b/test/compojure/api/perf_test.clj
@@ -36,7 +36,7 @@
   (->
     (app {:uri uri
           :request-method :post
-          :content-type "application/json"
+          :headers {"content-type" "application/json"}
           :body (io/input-stream (.getBytes json))})
     :body
     slurp))

--- a/test/compojure/api/resource_test.clj
+++ b/test/compojure/api/resource_test.clj
@@ -5,7 +5,7 @@
             [midje.sweet :refer :all]
             [ring.util.http-response :refer :all]
             [schema.core :as s])
-  (:import [clojure.lang ExceptionInfo]))
+  (:import (clojure.lang ExceptionInfo)))
 
 (defn has-body [expected]
   (fn [{:keys [body]}]

--- a/test/compojure/api/routes_test.clj
+++ b/test/compojure/api/routes_test.clj
@@ -6,9 +6,9 @@
             [ring.util.http-predicates :refer :all]
             [compojure.api.test-utils :refer :all]
             [schema.core :as s])
-  (:import [java.security SecureRandom]
-           [org.joda.time LocalDate]
-           [com.fasterxml.jackson.core JsonGenerationException]))
+  (:import (java.security SecureRandom)
+           (org.joda.time LocalDate)
+           (com.fasterxml.jackson.core JsonGenerationException)))
 
 (facts "path-string"
 

--- a/test/compojure/api/sweet_test.clj
+++ b/test/compojure/api/sweet_test.clj
@@ -104,106 +104,113 @@
   (fact "api-listing works"
     (let [spec (get-spec app)]
 
-      spec => {:swagger "2.0"
-               :info {:version "1.0.0"
-                      :title "Sausages"
-                      :description "Sausage description"
-                      :termsOfService "http://helloreverb.com/terms/"
-                      :contact {:name "My API Team"
-                                :email "foo@example.com"
-                                :url "http://www.metosin.fi"}
-                      :license {:name "Eclipse Public License"
-                                :url "http://www.eclipse.org/legal/epl-v10.html"}}
-               :basePath "/"
-               :consumes ["application/json"
-                          "application/x-yaml"
-                          "application/edn"
-                          "application/transit+json"
-                          "application/transit+msgpack"],
-               :produces ["application/json"
-                          "application/x-yaml"
-                          "application/edn"
-                          "application/transit+json"
-                          "application/transit+msgpack"]
-               :paths {"/api/bands" {:get {:x-name "bands"
-                                           :operationId "getBands"
-                                           :description "bands bands bands"
-                                           :responses {:200 {:description ""
-                                                             :schema {:items {:$ref "#/definitions/Band"}
-                                                                      :type "array"}}}
-                                           :summary "Gets all Bands"}
-                                     :post {:operationId "addBand"
-                                            :parameters [{:description ""
-                                                          :in "body"
-                                                          :name "NewBand"
-                                                          :required true
-                                                          :schema {:items {:$ref "#/definitions/NewBand"}
-                                                                   :type "array"}}]
-                                            :responses {:200 {:description ""
-                                                              :schema {:$ref "#/definitions/Band"}}}
-                                            :summary "Adds a Band"}}
-                       "/api/bands/{id}" {:get {:operationId "getBand"
-                                                :parameters [{:description ""
-                                                              :in "path"
-                                                              :name "id"
-                                                              :required true
-                                                              :type "string"}]
-                                                :responses {:200 {:description ""
-                                                                  :schema {:$ref "#/definitions/Band"}}}
-                                                :summary "Gets a Band"}}
-                       "/api/query" {:get {:parameters [{:in "query"
-                                                         :name "qp"
-                                                         :description ""
-                                                         :required true
-                                                         :type "boolean"}]
-                                           :responses {:default {:description ""}}}}
-                       "/api/header" {:get {:parameters [{:in "header"
-                                                          :name "hp"
-                                                          :description ""
-                                                          :required true
-                                                          :type "boolean"}]
-                                            :responses {:default {:description ""}}}}
-                       "/api/form" {:post {:parameters [{:in "formData"
-                                                         :name "fp"
-                                                         :description ""
-                                                         :required true
-                                                         :type "boolean"}]
-                                           :responses {:default {:description ""}}
-                                           :consumes ["application/x-www-form-urlencoded"]}}
-                       "/api/ping" {:get {:responses {:default {:description ""}}}}
-                       "/api/primitive" {:get {:responses {:200 {:description ""
-                                                                 :schema {:type "string"}}}}}
-                       "/api/primitiveArray" {:get {:responses {:200 {:description ""
-                                                                      :schema {:items {:type "string"}
-                                                                               :type "array"}}}}}
-                       "/ping" {:get {:responses {:default {:description ""}}}}}
-               :definitions {:Band {:type "object"
-                                    :properties {:description {:type "string"
-                                                               :x-nullable true}
-                                                 :id {:format "int64", :type "integer"}
-                                                 :name {:type "string"}
-                                                 :toppings {:items {:enum ["olives"
-                                                                           "pepperoni"
-                                                                           "ham"
-                                                                           "cheese"
-                                                                           "habanero"]
-                                                                    :type "string"}
-                                                            :type "array"}}
-                                    :required ["id" "name" "toppings"]
-                                    :additionalProperties false}
-                             :NewBand {:type "object"
-                                       :properties {:description {:type "string"
-                                                                  :x-nullable true}
-                                                    :name {:type "string"}
-                                                    :toppings {:items {:enum ["olives"
-                                                                              "pepperoni"
-                                                                              "ham"
-                                                                              "cheese"
-                                                                              "habanero"]
-                                                                       :type "string"}
-                                                               :type "array"}}
-                                       :required ["name" "toppings"]
-                                       :additionalProperties false}}}
+      spec => (just
+                {:swagger "2.0"
+                 :info {:version "1.0.0"
+                        :title "Sausages"
+                        :description "Sausage description"
+                        :termsOfService "http://helloreverb.com/terms/"
+                        :contact {:name "My API Team"
+                                  :email "foo@example.com"
+                                  :url "http://www.metosin.fi"}
+                        :license {:name "Eclipse Public License"
+                                  :url "http://www.eclipse.org/legal/epl-v10.html"}}
+                 :basePath "/"
+                 :consumes (just
+                             ["application/json"
+                              "application/x-yaml"
+                              "application/msgpack"
+                              "application/edn"
+                              "application/transit+json"
+                              "application/transit+msgpack"]
+                             :in-any-order),
+                 :produces (just
+                             ["application/json"
+                              "application/x-yaml"
+                              "application/msgpack"
+                              "application/edn"
+                              "application/transit+json"
+                              "application/transit+msgpack"]
+                             :in-any-order)
+                 :paths {"/api/bands" {:get {:x-name "bands"
+                                             :operationId "getBands"
+                                             :description "bands bands bands"
+                                             :responses {:200 {:description ""
+                                                               :schema {:items {:$ref "#/definitions/Band"}
+                                                                        :type "array"}}}
+                                             :summary "Gets all Bands"}
+                                       :post {:operationId "addBand"
+                                              :parameters [{:description ""
+                                                            :in "body"
+                                                            :name "NewBand"
+                                                            :required true
+                                                            :schema {:items {:$ref "#/definitions/NewBand"}
+                                                                     :type "array"}}]
+                                              :responses {:200 {:description ""
+                                                                :schema {:$ref "#/definitions/Band"}}}
+                                              :summary "Adds a Band"}}
+                         "/api/bands/{id}" {:get {:operationId "getBand"
+                                                  :parameters [{:description ""
+                                                                :in "path"
+                                                                :name "id"
+                                                                :required true
+                                                                :type "string"}]
+                                                  :responses {:200 {:description ""
+                                                                    :schema {:$ref "#/definitions/Band"}}}
+                                                  :summary "Gets a Band"}}
+                         "/api/query" {:get {:parameters [{:in "query"
+                                                           :name "qp"
+                                                           :description ""
+                                                           :required true
+                                                           :type "boolean"}]
+                                             :responses {:default {:description ""}}}}
+                         "/api/header" {:get {:parameters [{:in "header"
+                                                            :name "hp"
+                                                            :description ""
+                                                            :required true
+                                                            :type "boolean"}]
+                                              :responses {:default {:description ""}}}}
+                         "/api/form" {:post {:parameters [{:in "formData"
+                                                           :name "fp"
+                                                           :description ""
+                                                           :required true
+                                                           :type "boolean"}]
+                                             :responses {:default {:description ""}}
+                                             :consumes ["application/x-www-form-urlencoded"]}}
+                         "/api/ping" {:get {:responses {:default {:description ""}}}}
+                         "/api/primitive" {:get {:responses {:200 {:description ""
+                                                                   :schema {:type "string"}}}}}
+                         "/api/primitiveArray" {:get {:responses {:200 {:description ""
+                                                                        :schema {:items {:type "string"}
+                                                                                 :type "array"}}}}}
+                         "/ping" {:get {:responses {:default {:description ""}}}}}
+                 :definitions {:Band {:type "object"
+                                      :properties {:description {:type "string"
+                                                                 :x-nullable true}
+                                                   :id {:format "int64", :type "integer"}
+                                                   :name {:type "string"}
+                                                   :toppings {:items {:enum ["olives"
+                                                                             "pepperoni"
+                                                                             "ham"
+                                                                             "cheese"
+                                                                             "habanero"]
+                                                                      :type "string"}
+                                                              :type "array"}}
+                                      :required ["id" "name" "toppings"]
+                                      :additionalProperties false}
+                               :NewBand {:type "object"
+                                         :properties {:description {:type "string"
+                                                                    :x-nullable true}
+                                                      :name {:type "string"}
+                                                      :toppings {:items {:enum ["olives"
+                                                                                "pepperoni"
+                                                                                "ham"
+                                                                                "cheese"
+                                                                                "habanero"]
+                                                                         :type "string"}
+                                                                 :type "array"}}
+                                         :required ["name" "toppings"]
+                                         :additionalProperties false}}})
 
       (fact "spec is valid"
         (v/validate spec) => nil))))

--- a/test/compojure/api/test_utils.clj
+++ b/test/compojure/api/test_utils.clj
@@ -4,7 +4,7 @@
             [peridot.core :as p]
             [clojure.java.io :as io]
             [compojure.api.routes :as routes])
-  (:import [java.io InputStream]))
+  (:import (java.io InputStream)))
 
 (defn read-body [body]
   (if (instance? InputStream body)


### PR DESCRIPTION
Based on an idea to identify when a `context` is static: it doesn't bind any Compojure parameters nor Compojure-api `let`s or `letk`s via restructuring. For static contexts, we can don't have to create the routing closure for each request, but once per context.  Gives +30% better perf for a naive case and 4x better routing perf with middleware-heavy subrouting.