### PR TITLE
Add an example that shows exposing an endpoint for ring metrics.

### DIFF
--- a/examples/metrics-ring/README.md
+++ b/examples/metrics-ring/README.md
@@ -1,0 +1,24 @@
+# Simple compojure-api app
+
+## Usage
+
+### Run the application locally
+
+`lein ring server`
+
+### Packaging and running as standalone jar
+
+```
+lein do clean, ring uberjar
+java -jar target/server.jar
+```
+
+### Packaging as war
+
+`lein ring uberwar`
+
+## License
+
+Copyright © 2016 [Metosin Oy](http://www.metosin.fi)
+
+Distributed under the Eclipse Public License, the same as Clojure.

--- a/examples/metrics-ring/project.clj
+++ b/examples/metrics-ring/project.clj
@@ -1,0 +1,11 @@
+(defproject example "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [metosin/compojure-api "1.1.8"]
+
+                 [metrics-clojure "2.7.0"]
+                 [metrics-clojure-ring "2.7.0"]]
+
+  :ring {:handler example.handler/app}
+  :uberjar-name "server.jar"
+  :profiles {:dev {:plugins [[ikitommi/lein-ring "0.9.8-SNAPSHOT"]]}})

--- a/examples/metrics-ring/src/example/handler.clj
+++ b/examples/metrics-ring/src/example/handler.clj
@@ -1,0 +1,43 @@
+(ns example.handler
+  (:require [compojure.api.sweet :refer :all]
+            [ring.util.http-response :refer :all]
+            [metrics.ring.instrument :refer [instrument]]
+            [metrics.core :refer [default-registry]]
+            [metrics.ring.expose :refer [render-metrics]]
+            [schema.core :as s]))
+
+(s/defschema Pizza
+  {:name s/Str
+   (s/optional-key :description) s/Str
+   :size (s/enum :L :M :S)
+   :origin {:country (s/enum :FI :PO)
+            :city s/Str}})
+
+(def app
+  (instrument
+   (api
+    {:swagger
+     {:ui "/"
+      :spec "/swagger.json"
+      :data {:info {:title "Simple"
+                    :description "Compojure Api example"}
+             :tags [{:name "api", :description "some apis"}]}}}
+
+    (context "/api" []
+             :tags ["api"]
+
+             (GET "/metrics" []
+                  :summary "Application level metrics."
+                  (ok (render-metrics default-registry)))
+
+             (GET "/plus" []
+                  :return {:result Long}
+                  :query-params [x :- Long, y :- Long]
+                  :summary "adds two numbers together"
+                  (ok {:result (+ x y)}))
+
+             (POST "/echo" []
+                   :return Pizza
+                   :body [pizza Pizza]
+                   :summary "echoes a Pizza"
+                   (ok pizza))))))


### PR DESCRIPTION
See http://metrics-clojure.readthedocs.io/en/latest/ for information on integration with graphing services, instrumentation of the JVM, or instrumentation of specific routes.