### PR TITLE
Don't keywordize :body keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 * Fix Cider indentation for route macros, by [Joe Littlejohn](https://github.com/joelittlejohn)
+* Restructuring `:body` does not keywordize all keys,
+  * e.g. EDN & Transit keys are not transformed, JSON keys based on the JSON decoder settings (defaulting to `true`).
 
 * Updated deps:
 
@@ -117,7 +119,7 @@
        :data {:info {:title "Kikka"}
               :paths {"/ping" {:get {:summary "ping get"}}}}})
     (GET "/ping" [] "pong"))))
-```    
+```
 
 * unsetting `:format` option in `api-middleware` causes all format-middlewares not to mount
 * unsetting `:exceptions` option in `api-middleware` causes the exception handling to be disabled
@@ -145,7 +147,7 @@
 * fix reflection warning with logging, thanks to [Matt K](https://github.com/mtkp).
 * Empty contexts (`/`) don't accumulate to the path, see https://github.com/weavejester/compojure/issues/125
 
-* **NOTE**: update of `ring-http-response` had a [breaking change](https://github.com/metosin/ring-http-response/blob/master/CHANGELOG.md#080-2862016): 
+* **NOTE**: update of `ring-http-response` had a [breaking change](https://github.com/metosin/ring-http-response/blob/master/CHANGELOG.md#080-2862016):
   - first argument for `created` is `url`, not `body`. Has 2-arity version which takes both `url` & `body` in align to the [spec](http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html) & [ring](https://github.com/ring-clojure/ring/blob/master/ring-core/src/ring/util/response.clj#L37)
    - fixes [#12](https://github.com/metosin/ring-http-response/issues/12).
 

--- a/src/compojure/api/coerce.clj
+++ b/src/compojure/api/coerce.clj
@@ -38,9 +38,9 @@
                   body (coerce (:body response))]
               (if (su/error? body)
                 (throw (ex-info
-                        (str "Response validation failed: " (su/error-val body))
-                        (assoc body :type ::ex/response-validation
-                               :response response)))
+                         (str "Response validation failed: " (su/error-val body))
+                         (assoc body :type ::ex/response-validation
+                                     :response response)))
                 (assoc response
                   :compojure.api.meta/serializable? true
                   :body body))))))
@@ -50,8 +50,9 @@
   (fn [request]
     (coerce-response! request (handler request) responses)))
 
-(defn coerce! [schema key type request]
-  (let [value (walk/keywordize-keys (key request))]
+(defn coerce! [schema key type keywordize? request]
+  (let [transform (if keywordize? walk/keywordize-keys identity)
+        value (transform (key request))]
     (if-let [matchers (mw/coercion-matchers request)]
       (if-let [matcher (matchers type)]
         (let [coercer (cached-coercer request)

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -33,9 +33,10 @@
 (s/defn src-coerce!
   "Return source code for coerce! for a schema with coercion type,
   extracted from a key in a ring request."
-  [schema, key, type :- mw/CoercionType]
-  (assert (not (#{:query :json} type)) (str type " is DEPRECATED since 0.22.0. Use :body or :string instead."))
-  `(coerce/coerce! ~schema ~key ~type ~+compojure-api-request+))
+  ([schema, key, type :- mw/CoercionType]
+    (src-coerce! schema, key, type, true))
+  ([schema, key, type :- mw/CoercionType, keywordize?]
+    `(coerce/coerce! ~schema ~key ~type ~keywordize? ~+compojure-api-request+)))
 
 (defn- convert-return [schema]
   {200 {:schema schema
@@ -129,7 +130,7 @@
 ; :body [user User]
 (defmethod restructure-param :body [_ [value schema] acc]
   (-> acc
-      (update-in [:lets] into [value (src-coerce! schema :body-params :body)])
+      (update-in [:lets] into [value (src-coerce! schema :body-params :body false)])
       (assoc-in [:swagger :parameters :body] schema)))
 
 ; reads query-params into a enhanced let. First parameter is the let symbol,

--- a/src/compojure/api/resource.clj
+++ b/src/compojure/api/resource.clj
@@ -30,7 +30,7 @@
     (fn [request ring-key [compojure-key _ type open?]]
       (if-let [schema (get-in info (concat ks [:parameters ring-key]))]
         (let [schema (if open? (assoc schema s/Keyword s/Any) schema)]
-          (update request ring-key merge (coerce/coerce! schema compojure-key type request)))
+          (update request ring-key merge (coerce/coerce! schema compojure-key type (not= :body type) request)))
         request))
     request
     (:parameters +mappings+)))

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -5,6 +5,7 @@
             [compojure.api.swagger :as swagger]
             [midje.sweet :refer :all]
             [ring.util.http-response :refer :all]
+            [ring.util.http-predicates :as http]
             [schema.core :as s]
             [ring.swagger.core :as rsc]
             [ring.util.http-status :as status]
@@ -14,7 +15,9 @@
             [compojure.api.routes :as routes]
             [muuntaja.core :as muuntaja]
             [muuntaja.core :as formats]
-            [cheshire.core :as json]))
+            [cheshire.core :as json]
+            [clojure.java.io :as io]
+            [muuntaja.core :as m]))
 
 ;;
 ;; Data
@@ -1429,7 +1432,7 @@
 
 (facts "custom formats contribute to Swagger :consumes & :produces"
   (let [custom-type "application/vnd.vendor.v1+json"
-        custom-format {:decoder [muuntaja.formats/make-json-decoder]
+        custom-format {:decoder [muuntaja.formats/make-json-decoder {:key-fn true}]
                        :encoder [muuntaja.formats/make-json-encoder]}
         app (api
               {:swagger {:spec "/swagger.json"}
@@ -1455,3 +1458,45 @@
       => (contains
            {:produces (just ["application/vnd.vendor.v1+json" "application/json"] :in-any-order)
             :consumes (just ["application/vnd.vendor.v1+json" "application/json"] :in-any-order)}))))
+
+(facts ":body doesn't keywordize keys"
+  (let [m (muuntaja.core/create)
+        data {:items {"kikka" 42}}
+        body* (atom nil)
+        app (api
+              (swagger-routes)
+              (POST "/echo" []
+                :body-params [items :- {:kikka Long}]
+                (reset! body* {:items items})
+                (ok))
+              (POST "/echo2" []
+                :body [body {:items {(s/required-key "kikka") Long}}]
+                (reset! body* body)
+                (ok)))]
+
+    (facts ":body-params keywordizes params"
+      (app {:uri "/echo"
+            :request-method :post
+            :body (m/encode m "application/transit+json" data)
+            :headers {"content-type" "application/transit+json"
+                      "accept" "application/transit+json"}}) => http/ok?
+      @body* => {:items {:kikka 42}})
+
+    (facts ":body does not keywordizes params"
+      (app {:uri "/echo2"
+            :request-method :post
+            :body (m/encode m "application/transit+json" data)
+            :headers {"content-type" "application/transit+json"
+                      "accept" "application/transit+json"}}) => http/ok?
+      @body* => {:items {"kikka" 42}})
+
+    (facts "swagger spec is generated both ways"
+      (let [spec (get-spec app)
+            echo-schema-name (-> (get-in spec [:paths "/echo" :post :parameters 0 :name])
+                                 name (str "Items") keyword)
+            echo2-schema-name (-> (get-in spec [:paths "/echo2" :post :parameters 0 :name])
+                                  name (str "Items") keyword)
+            echo-schema (get-in spec [:definitions echo-schema-name :properties])
+            echo2-schema (get-in spec [:definitions echo2-schema-name :properties])]
+        echo-schema => {:kikka {:type "integer", :format "int64"}}
+        echo2-schema => {:kikka {:type "integer", :format "int64"}}))))

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -17,7 +17,7 @@
             [muuntaja.core :as formats]
             [cheshire.core :as json]
             [clojure.java.io :as io]
-            [muuntaja.core :as m]))
+            [muuntaja.core :as muuntaja]))
 
 ;;
 ;; Data
@@ -1460,7 +1460,7 @@
             :consumes (just ["application/vnd.vendor.v1+json" "application/json"] :in-any-order)}))))
 
 (facts ":body doesn't keywordize keys"
-  (let [m (muuntaja.core/create)
+  (let [m (muuntaja/create)
         data {:items {"kikka" 42}}
         body* (atom nil)
         app (api
@@ -1477,7 +1477,7 @@
     (facts ":body-params keywordizes params"
       (app {:uri "/echo"
             :request-method :post
-            :body (m/encode m "application/transit+json" data)
+            :body (muuntaja/encode m "application/transit+json" data)
             :headers {"content-type" "application/transit+json"
                       "accept" "application/transit+json"}}) => http/ok?
       @body* => {:items {:kikka 42}})
@@ -1485,7 +1485,7 @@
     (facts ":body does not keywordizes params"
       (app {:uri "/echo2"
             :request-method :post
-            :body (m/encode m "application/transit+json" data)
+            :body (muuntaja/encode m "application/transit+json" data)
             :headers {"content-type" "application/transit+json"
                       "accept" "application/transit+json"}}) => http/ok?
       @body* => {:items {"kikka" 42}})

--- a/test/compojure/api/meta_test.clj
+++ b/test/compojure/api/meta_test.clj
@@ -1,7 +1,0 @@
-(ns compojure.api.meta-test
-  (:require [compojure.api.meta :refer :all]
-            [midje.sweet :refer :all]))
-
-(fact "src-coerce! with deprecated types"
-  (src-coerce! nil nil :query) => (throws AssertionError)
-  (src-coerce! nil nil :json) => (throws AssertionError))


### PR DESCRIPTION
* Restructuring `:body` does not keywordize all keys,
  * e.g. EDN & Transit keys are not transformed, JSON keys based on the JSON decoder settings (defaulting to `true`).
