### PR TITLE
More configurable coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0-20161115.083911-5
+## 1.2.0-20161028.114958-3
 
 * Fix Cider indentation for route macros, by [Joe Littlejohn](https://github.com/joelittlejohn)
 * Restructuring `:body` does not keywordize all keys,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ nil
 * Updated deps:
 
 ```
+[cheshire "5.7.0"] is available but we use "5.6.3"
 [compojure "1.5.2"] is available but we use "1.5.1"
 [metosin/ring-http-response "0.8.1"] is available but we use "0.8.0"
 [metosin/ring-swagger "0.22.14"] is available but we use "0.22.12"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,52 @@
-## Unreleased
+## 0.2.0-20161115.083911-5
 
 * Fix Cider indentation for route macros, by [Joe Littlejohn](https://github.com/joelittlejohn)
 * Restructuring `:body` does not keywordize all keys,
   * e.g. EDN & Transit keys are not transformed, JSON keys based on the JSON decoder settings (defaulting to `true`).
+* **BREAKING**: Default coercion (`compojure.api.middleware`), fixes [#266](https://github.com/metosin/compojure-api/issues/266)
+  * same contract as before, but with better default implementation
+  * remove the `default-coercion-matchers`
+  * new `create-coercion` & `default-coercion-options` for more fine grained access, uses format information prodived by [Muuntaja](https://github.com/metosin/muuntaja#request) to get format-level coercion.
+  * old default coercion rules:
+    * coerce everything (request & response body) with `json-coercion-matcher`
+  * new default coercion rules:
+
+| Format | Request | Response |
+| --------|:-------:|:------------:|
+| `application/json` | `json-coercion-matcher` | validate |
+| `application/edn` | `json-coercion-matcher` | validate |
+| `application/msgpack` | `json-coercion-matcher` | validate |
+| `application/x-yaml` | `json-coercion-matcher` | validate |
+| `application/transit+json` | validate | validate |
+| `application/transit+msgpack` | validate | validate |
+
+as code:
+
+```clj
+(def default-coercion-options
+  {:body {:default (constantly nil)
+          :formats {"application/json" json-coercion-matcher
+                    "application/msgpack" json-coercion-matcher
+                    "application/x-yaml" json-coercion-matcher}}
+   :string string-coercion-matcher
+   :response {:default (constantly nil)
+              :formats {}}})
+```
+
+to create a valid `coercion` (for api or to routes):
+
+```clj
+;; create (with defaults)
+(mw/create-coercion)
+(mw/create-coercion mw/default-coercion-options)
+
+;; no response coercion
+(mw/create-coercion (dissoc mw/default-coercion-options :response)
+
+;; disable all coercion
+nil
+(mw/create-coercion nil)
+```
 
 * Updated deps:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,8 @@ nil
 
 * Updated deps:
 
-```
+```clj
 [cheshire "5.7.0"] is available but we use "5.6.3"
-[compojure "1.5.2"] is available but we use "1.5.1"
 [metosin/ring-http-response "0.8.1"] is available but we use "0.8.0"
 [metosin/ring-swagger "0.22.14"] is available but we use "0.22.12"
 [metosin/ring-swagger-ui "2.2.8"] is available but we use "2.2.5-0"

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Stuff on top of [Compojure](https://github.com/weavejester/compojure) for making
 
 [![Clojars Project](http://clojars.org/metosin/compojure-api/latest-version.svg)](http://clojars.org/metosin/compojure-api)
 
+Want to play with the latest code? try `[metosin/compojure-api "1.2.0-20161028.114958-3"]`. See [CHANGELOG](https://github.com/metosin/compojure-api/blob/master/CHANGELOG.md) for details.
+
 ## For information and help
 
 ### [Read the Version 1.0 Blog Post](http://www.metosin.fi/blog/compojure-api-100/)

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :distribution :repo
             :comments "same as Clojure"}
   :dependencies [[potemkin "0.4.3"]
-                 [cheshire "5.6.3"]
+                 [cheshire "5.7.0"]
                  [compojure "1.5.2"]
                  [prismatic/schema "1.1.3"]
                  [prismatic/plumbing "0.5.3"]

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -81,15 +81,19 @@
 ;; coercion
 ;;
 
+(def string-coercion-matcher coerce/query-schema-coercion-matcher)
+(def json-coercion-matcher coerce/json-schema-coercion-matcher)
+
 (s/defschema CoercionType (s/enum :body :string :response))
 
 (def default-coercion-options
   {:body {:default (constantly nil)
-          :formats {"application/json" coerce/json-schema-coercion-matcher}}
-   :string coerce/query-schema-coercion-matcher
+          :formats {"application/json" json-coercion-matcher
+                    "application/msgpack" json-coercion-matcher
+                    "application/x-yaml" json-coercion-matcher}}
+   :string string-coercion-matcher
    :response {:default (constantly nil)
-              ;; TODO: don't auto-coerce the JSON responses? => would be a breaking change in 1.2
-              :formats {"application/json" coerce/json-schema-coercion-matcher}}})
+              :formats {}}})
 
 (defn create-coercion
   ([] (create-coercion default-coercion-options))

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -89,7 +89,7 @@
                     "application/yaml" coerce/query-schema-coercion-matcher}}
    :string coerce/query-schema-coercion-matcher
    :response {:default (constantly nil)
-              ;; FIXME: don't auto-coerce the JSON responses? => would be a breaking change in 1.2
+              ;; TODO: don't auto-coerce the JSON responses? => would be a breaking change in 1.2
               :formats {"application/json" coerce/json-schema-coercion-matcher}}})
 
 (defn create-coercion

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -85,8 +85,7 @@
 
 (def default-coercion-options
   {:body {:default (constantly nil)
-          :formats {"application/json" coerce/json-schema-coercion-matcher
-                    "application/yaml" coerce/query-schema-coercion-matcher}}
+          :formats {"application/json" coerce/json-schema-coercion-matcher}}
    :string coerce/query-schema-coercion-matcher
    :response {:default (constantly nil)
               ;; TODO: don't auto-coerce the JSON responses? => would be a breaking change in 1.2

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -83,11 +83,6 @@
 
 (s/defschema CoercionType (s/enum :body :string :response))
 
-(def default-coercion-matchers
-  {:body coerce/json-schema-coercion-matcher
-   :string coerce/query-schema-coercion-matcher
-   :response coerce/json-schema-coercion-matcher})
-
 (def default-coercion-options
   {:body {:default (constantly nil)
           :formats {"application/json" coerce/json-schema-coercion-matcher

--- a/test/compojure/api/coercion_test.clj
+++ b/test/compojure/api/coercion_test.clj
@@ -81,7 +81,7 @@
             body => {:beers ["ipa" "apa"]})))
 
       (fact "body-coercion can be disabled"
-        (let [no-body-coercion (constantly (dissoc mw/default-coercion-matchers :body))
+        (let [no-body-coercion (mw/create-coercion (dissoc mw/default-coercion-options :body))
               app (api
                     {:coercion no-body-coercion}
                     beer-route)]
@@ -96,7 +96,7 @@
             body => {:beers ["ipa" "apa" "ipa"]})))
 
       (fact "body-coercion can be changed"
-        (let [nop-body-coercion (constantly (assoc mw/default-coercion-matchers :body (constantly nil)))
+        (let [nop-body-coercion (mw/create-coercion (assoc mw/default-coercion-options :body {:default (constantly nil)}))
               app (api
                     {:coercion nop-body-coercion}
                     beer-route)]
@@ -115,7 +115,7 @@
             body => {:i 10})))
 
       (fact "query-coercion can be disabled"
-        (let [no-query-coercion (constantly (dissoc mw/default-coercion-matchers :string))
+        (let [no-query-coercion (mw/create-coercion (dissoc mw/default-coercion-options :string))
               app (api
                     {:coercion no-query-coercion}
                     query-route)]
@@ -124,7 +124,7 @@
             body => {:i "10"})))
 
       (fact "query-coercion can be changed"
-        (let [nop-query-coercion (constantly (assoc mw/default-coercion-matchers :string (constantly nil)))
+        (let [nop-query-coercion (mw/create-coercion (assoc mw/default-coercion-options :string (constantly nil)))
               app (api
                     {:coercion nop-query-coercion}
                     query-route)]
@@ -136,7 +136,7 @@
                   :query-params [i :- s/Int]
                   (ok {:i i}))
                 (GET "/disabled-coercion" []
-                  :coercion (constantly (assoc mw/default-coercion-matchers :string (constantly nil)))
+                  :coercion (mw/create-coercion (assoc mw/default-coercion-options :string (constantly nil)))
                   :query-params [i :- s/Int]
                   (ok {:i i}))
                 (GET "/no-coercion" []

--- a/test/compojure/api/test_utils.clj
+++ b/test/compojure/api/test_utils.clj
@@ -3,7 +3,8 @@
             [clojure.string :as str]
             [peridot.core :as p]
             [clojure.java.io :as io]
-            [compojure.api.routes :as routes])
+            [compojure.api.routes :as routes]
+            [muuntaja.core :as muuntaja])
   (:import (java.io InputStream)))
 
 (defn read-body [body]
@@ -83,6 +84,16 @@
   (let [[status body] (raw-post* app uri "" nil headers)]
     [status (parse-body body)]))
 
+;;
+;; ring-request
+;;
+
+(defn ring-request [m format data]
+  {:uri "/echo"
+   :request-method :post
+   :body (muuntaja/encode m format data)
+   :headers {"content-type" format
+             "accept" format}})
 ;;
 ;; get-spec
 ;;


### PR DESCRIPTION
replace implementation (not the contract) of default coercion. in `compojure.api.middleware`:
  * remove `default-coercion-matchers`
  * use `create-coercion` & `default-coercion-options` instead for more fine grained access, uses format information prodived by [Muuntaja](https://github.com/metosin/muuntaja#request) to get format-level coercion.
  * **BREAKING** new default coercion rules:

| Format | Request | Response |
| --------|:-------:|:------------:|
| `application/json` | `json-coercion-matcher` | validate |
| `application/edn` | `json-coercion-matcher` | validate |
| `application/msgpack` | `json-coercion-matcher` | validate |
| `application/x-yaml` | `json-coercion-matcher` | validate |
| `application/transit+json` | validate | validate |
| `application/transit+msgpack` | validate | validate |

default options (**updated**):

```clj
(def default-coercion-options
  {:body {:default (constantly nil)
          :formats {"application/json" json-coercion-matcher
                    "application/msgpack" json-coercion-matcher
                    "application/x-yaml" json-coercion-matcher}}
   :string string-coercion-matcher
   :response {:default (constantly nil)
              :formats {}}})
```

to create a valid `coercion` (for api or to routes):

```clj
;; create (with defaults)
(mw/create-coercion)
(mw/create-coercion mw/default-coercion-options)

;; no response coercion
(mw/create-coercion (dissoc mw/default-coercion-options :response)

;; disable all coercion
nil
(mw/create-coercion nil)
``` 

Why? More correct behaviour for EDN & Transit, easy to add own custom rules based on formats.

See https://github.com/metosin/compojure-api/issues/266