### PR TITLE
Initial implementation for inline help

### DIFF
--- a/src/compojure/api/help.clj
+++ b/src/compojure/api/help.clj
@@ -1,0 +1,69 @@
+(ns compojure.api.help
+  (:require [schema.core :as s]
+            [clojure.string :as str]))
+
+(def Topic (s/maybe s/Keyword))
+(def Subject (s/maybe (s/cond-pre s/Str s/Keyword s/Symbol)))
+
+;;
+;; content formatting
+;;
+
+(defn text [& s]
+  (->> s
+       (map #(if (seq? %) (apply text %) %))
+       (str/join "\n")))
+
+(defn title [& s]
+  (str "\u001B[32m" (text s) "\u001B[0m"))
+
+(defn code [& s]
+  (str "\u001B[33m" (text s) "\u001B[0m"))
+
+(defmulti help-for (fn [topic subject] [topic subject]) :default ::default)
+
+(defn- subject-text [topic subject]
+  (text
+    (title subject)
+    ""
+    (help-for topic subject)))
+
+(defn- topic-text [topic]
+  (let [subjects (-> (methods help-for)
+                     (dissoc ::default)
+                     (keys)
+                     (->> (filter #(-> % first (= topic)))))]
+    (text
+      "Topic:\n"
+      (title topic)
+      "\nSubjects:"
+      (->> subjects
+           (map (partial apply subject-text))
+           (map (partial str "\n"))))))
+
+(defn- help-text []
+  (let [methods (dissoc (methods help-for) ::default)]
+    (text
+      "Usage:"
+      ""
+      (code
+        "(help)"
+        "(help topic)"
+        "(help topic subject)")
+      "\nTopics:\n"
+      (title (->> methods keys (map first) (distinct)))
+      "\nTopics & subjects:\n"
+      (title (->> methods keys (map (partial str/join " ")))))))
+
+(defmethod help-for ::default [_ _] (help-text))
+
+(s/defn ^:always-validate help
+  ([]
+    (println "------------------------------------------------------------")
+    (println (help-text)))
+  ([topic :- Topic]
+    (println "------------------------------------------------------------")
+    (println (topic-text topic)))
+  ([topic :- Topic, subject :- Subject]
+    (println "------------------------------------------------------------")
+    (println (subject-text topic subject))))

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -9,6 +9,7 @@
             [schema.core :as s]
             [schema-tools.core :as st]
             [compojure.api.coerce :as coerce]
+            [compojure.api.help :as help]
             compojure.core))
 
 (def +compojure-api-request+
@@ -54,6 +55,17 @@
 ;;
 ;; Pass-through swagger metadata
 ;;
+
+
+(defmethod help/help-for [:restructuring :summary] [_ _]
+  (help/text
+    "A short summary of what the operation does. For maximum"
+    "readability in the swagger-ui, this field SHOULD be less"
+    "than 120 characters.\n"
+    (help/code
+      "(GET \"/ok\""
+      "  :summary \"this endpoint alreays returns 200\""
+      "  (ok))")))
 
 (defmethod restructure-param :summary [k v acc]
   (update-in acc [:swagger] assoc k v))
@@ -185,8 +197,21 @@
         (update-in [:letks] into [header-params (src-coerce! schema :headers :string)])
         (assoc-in [:swagger :parameters :header] schema))))
 
-; restructures query-params with plumbing letk notation. Example:
-; :query-params [id :- Long name :- String]
+;;
+;; :query-params
+;;
+
+(defmethod help/help-for [:restructuring :query-params] [_ _]
+  (help/text
+    "Restructures query-params with plumbing letk notation.\n"
+    "Example: read x and optionally y (defaulting to 1)"
+    "from query parameters. Body of the endpoint sees the"
+    "coerced values.\n"
+    (help/code
+      "(GET \"/ping\""
+      "  :query-params [x :- Long, {y :- Long 1}]"
+      "  (ok (+ x y)))")))
+
 (defmethod restructure-param :query-params [_ query-params acc]
   (let [schema (fnk-schema query-params)]
     (-> acc

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -53,9 +53,8 @@
   (fn [k v acc] k))
 
 ;;
-;; Pass-through swagger metadata
+;; summary
 ;;
-
 
 (defmethod help/help-for [:restructuring :summary] [_ _]
   (help/text
@@ -70,14 +69,39 @@
 (defmethod restructure-param :summary [k v acc]
   (update-in acc [:swagger] assoc k v))
 
+;;
+;; description
+;;
+
+(defmethod help/help-for [:restructuring :description] [_ _]
+  (help/text
+    "A verbose explanation of the operation behavior."
+    "GFM syntax can be used for rich text representation."
+    (help/code
+      "(GET \"/ok\""
+      "  :description \"this is a `GET`.\""
+      "  (ok))")))
+
 (defmethod restructure-param :description [k v acc]
   (update-in acc [:swagger] assoc k v))
+
+;;
+;; OperationId
+;;
 
 (defmethod restructure-param :operationId [k v acc]
   (update-in acc [:swagger] assoc k v))
 
+;;
+;; Consumes
+;;
+
 (defmethod restructure-param :consumes [k v acc]
   (update-in acc [:swagger] assoc k v))
+
+;;
+;; Provides
+;;
 
 (defmethod restructure-param :produces [k v acc]
   (update-in acc [:swagger] assoc k v))


### PR DESCRIPTION
WIP.

```clojure
(require '[compojure.api.help :refer [help]])

(help)
; ------------------------------------------------------------
; Usage:
; 
; (help)
; (help topic)
; (help topic subject)
; 
; Topics:
; 
; :restructuring
; 
; Topics & subjects:
; 
; :restructuring :query-params
; :restructuring :summary

(help :restructuring)
; ------------------------------------------------------------
; Topic:
; 
; :restructuring
; 
; Subjects:
; 
; :query-params
; 
; Restructures query-params with plumbing letk notation.
; 
; Example: read x and optionally y (defaulting to 1)
; from query parameters. Body of the endpoint sees the
; coerced values.
; 
; (GET "/ping"
;   :query-params [x :- Long, {y :- Long 1}]
;   (ok (+ x y)))
; 
; :summary
; 
; A short summary of what the operation does. For maximum
; readability in the swagger-ui, this field SHOULD be less
; than 120 characters.
; 
; (GET "/ok"
;   :summary "this endpoint alreays returns 200"
;   (ok))
```

... help can be of anything. contributing to help:

```clojure
(defmethod help/help-for [:restructuring :query-params] [_ _]
  (help/text
    "Restructures query-params with plumbing letk notation.\n"
    "Example: read x and optionally y (defaulting to 1)"
    "from query parameters. Body of the endpoint sees the"
    "coerced values.\n"
    (help/code
      "(GET \"/ping\""
      "  :query-params [x :- Long, {y :- Long 1}]"
      "  (ok (+ x y)))")))
```