### PR TITLE
Class-based exception dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## UNRELEASED
+
+* class-based exception handling made easier, the `[:exceptions :handlers]` options also takes the exception class names as keys,
+used if the `:type`-based matching doesn't find a suitable handler: first against the exception class then the exception cause class.
+
+
+```clj
+(api
+  {:exceptions
+   {:handlers
+     {::ex/default (custom-exception-handler :custom-exception)
+      IllegalAccessException (custom-exception-handler :illegal)}}}
+   ...)
+```
+
 ## 1.2.0-alpha2 (22.1.2017)
 
 **this is an alpha release, feedback welcome**

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
             :comments "same as Clojure"}
   :dependencies [[potemkin "0.4.3"]
                  [cheshire "5.7.0"]
-                 [compojure "1.5.2"]
+                 [compojure "1.5.2" :exclusions [commons-codec]]
                  [prismatic/schema "1.1.3"]
                  [prismatic/plumbing "0.5.3"]
                  [org.tobereplaced/lettercase "1.0.0"]

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -43,7 +43,10 @@
         (catch Throwable e
           (let [{:keys [type] :as data} (ex-data e)
                 type (or (get ex/mapped-exception-types type) type)
-                handler (or (get handlers type) default-handler)]
+                handler (or (get handlers type)
+                            (get handlers (class e))
+                            (get handlers (class (.getCause e)))
+                            default-handler)]
             ; FIXME: Used for validate
             (if (rethrow-exceptions? request)
               (throw e)

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -983,15 +983,15 @@
       (let [[_ body] (get* app "/specific-error")]
         body => {:custom-error "my error"}))
 
-    (fact "direct class-based"
+    (fact "direct class"
       (let [[_ body] (get* app "/class")]
         body => (contains {:illegal irrelevant})))
 
-    (fact "direct class-based"
+    (fact "nested class"
       (let [[_ body] (get* app "/with-class-cause")]
         body => (contains {:illegal irrelevant})))
 
-    (fact "missing nested exception checking works"
+    (fact "missing nested class doesn't throw NPE"
       (let [[_ body] (get* app "/without-class-cause")]
         body => (contains {:custom-exception irrelevant})))))
 

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -18,7 +18,8 @@
             [cheshire.core :as json]
             [clojure.java.io :as io]
             [muuntaja.core :as muuntaja]
-            [muuntaja.core :as m]))
+            [muuntaja.core :as m])
+  (:import (java.lang ReflectiveOperationException)))
 
 ;;
 ;; Data
@@ -77,8 +78,9 @@
       ::ex/response-validation (not-implemented error-body)
       (bad-request error-body))))
 
-(defn custom-exception-handler [^Exception ex data request]
-  (ok {:custom-exception (str ex)}))
+(defn custom-exception-handler [key]
+  (fn [^Exception ex data request]
+    (ok {key (str ex)})))
 
 (defn custom-error-handler [ex data request]
   (ok {:custom-error (:data data)}))
@@ -950,7 +952,8 @@
 
 (fact "exceptions options with custom exception and error handler"
   (let [app (api
-              {:exceptions {:handlers {::ex/default custom-exception-handler
+              {:exceptions {:handlers {::ex/default (custom-exception-handler :custom-exception)
+                                       IllegalAccessException (custom-exception-handler :illegal)
                                        ::custom-error custom-error-handler}}}
               (swagger-routes)
               (GET "/some-exception" []
@@ -958,7 +961,13 @@
               (GET "/some-error" []
                 (throw (ex-info "some ex info" {:data "some error" :type ::some-error})))
               (GET "/specific-error" []
-                (throw (ex-info "my ex info" {:data "my error" :type ::custom-error}))))]
+                (throw (ex-info "my ex info" {:data "my error" :type ::custom-error})))
+              (GET "/class" []
+                (throw (IllegalAccessException. "kosh")))
+              (GET "/with-class-cause" []
+                (throw (ReflectiveOperationException. "kosh" (IllegalAccessException.))))
+              (GET "/without-class-cause" []
+                (throw (ReflectiveOperationException. "kosh"))))]
 
     (fact "uses default exception handler for unknown exceptions"
       (let [[status body] (get* app "/some-exception")]
@@ -971,8 +980,20 @@
         (:custom-exception body) => (contains ":data \"some error\"")))
 
     (fact "uses specific error handler for ::custom-errors"
-      (let [[status body] (get* app "/specific-error")]
-        body => {:custom-error "my error"}))))
+      (let [[_ body] (get* app "/specific-error")]
+        body => {:custom-error "my error"}))
+
+    (fact "direct class-based"
+      (let [[_ body] (get* app "/class")]
+        body => (contains {:illegal irrelevant})))
+
+    (fact "direct class-based"
+      (let [[_ body] (get* app "/with-class-cause")]
+        body => (contains {:illegal irrelevant})))
+
+    (fact "missing nested exception checking works"
+      (let [[_ body] (get* app "/without-class-cause")]
+        body => (contains {:custom-exception irrelevant})))))
 
 (fact "exception handling can be disabled"
   (let [app (api


### PR DESCRIPTION
* class-based exception handling made easier, the `[:exceptions :handlers]` options also takes the exception class names as keys,
used if the `:type`-based matching doesn't find a suitable handler: first against the exception class then the exception cause class.


```clojure
(api
  {:exceptions
   {:handlers
     {::ex/default (custom-exception-handler :custom-exception)
      IllegalAccessException (custom-exception-handler :illegal)}}}
   ...)
```