### PR TITLE
Fix help-for for some restructure methods

### DIFF
--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -270,7 +270,7 @@
 ;; query
 ;;
 
-(defmethod help/help-for [:meta :body] [_ _]
+(defmethod help/help-for [:meta :query] [_ _]
   (help/text
     "query-params with let-syntax. First parameter is the symbol,"
     "second is the Schema used in coercion (and api-docs).\n"
@@ -288,13 +288,13 @@
 ;; headers
 ;;
 
-(defmethod help/help-for [:meta :body] [_ _]
+(defmethod help/help-for [:meta :headers] [_ _]
   (help/text
     "header-params with let-syntax. First parameter is the symbol,"
     "second is the Schema used in coercion (and api-docs).\n"
     (help/code
       "(GET \"/headers\" []"
-      "  :query [headers HeaderSchema]"
+      "  :headers [headers HeaderSchema]"
       "  (ok headers))")))
 
 (defmethod restructure-param :headers [_ [value schema] acc]
@@ -390,7 +390,7 @@
 ;; :query-params
 ;;
 
-(defmethod help/help-for [:meta :header-params] [_ _]
+(defmethod help/help-for [:meta :query-params] [_ _]
   (help/text
     "query-params with letk. Schema is used for both coercion and api-docs."
     "https://github.com/plumatic/plumbing/tree/master/src/plumbing/fnk#fnk-syntax\n"

--- a/test/compojure/api/help_test.clj
+++ b/test/compojure/api/help_test.clj
@@ -6,6 +6,8 @@
 (facts help-for-api-meta
   (fact "all restructure-param methods have a help text"
     (let [restructure-method-names (-> (methods api.meta/restructure-param)
+                                       (dissoc :compojure.api.integration-test/deprecated-middlewares-test
+                                               :compojure.api.integration-test/deprecated-parameters-test)
                                        keys)
           meta-help-topics (-> (methods help/help-for)
                                (dissoc  ::help/default)

--- a/test/compojure/api/help_test.clj
+++ b/test/compojure/api/help_test.clj
@@ -1,0 +1,16 @@
+(ns compojure.api.help-test
+  (:require [compojure.api.help :as help]
+            [compojure.api.meta :as api.meta]
+            [midje.sweet :refer :all]))
+
+(facts help-for-api-meta
+  (fact "all restructure-param methods have a help text"
+    (let [restructure-method-names (-> (methods api.meta/restructure-param)
+                                       keys
+                                       (conj :bla))
+          meta-help-topics (-> (methods help/help-for)
+                               (dissoc  ::help/default)
+                               keys
+                               (->> (filter #(= :meta (first %)))
+                                    (map second)))]
+      (set restructure-method-names) => (set meta-help-topics))))

--- a/test/compojure/api/help_test.clj
+++ b/test/compojure/api/help_test.clj
@@ -6,8 +6,7 @@
 (facts help-for-api-meta
   (fact "all restructure-param methods have a help text"
     (let [restructure-method-names (-> (methods api.meta/restructure-param)
-                                       keys
-                                       (conj :bla))
+                                       keys)
           meta-help-topics (-> (methods help/help-for)
                                (dissoc  ::help/default)
                                keys


### PR DESCRIPTION
Wrong keys were being used as dispatch values for some `help-for` defmethods, so the help for those `restructure-param` methods was not available.

Adds a test to verify that each and every `restructure-param` methods has a corresponding `help-for` method.