### PR TITLE
Allow nil paths

### DIFF
--- a/src/compojure/api/core.clj
+++ b/src/compojure/api/core.clj
@@ -4,14 +4,11 @@
             [compojure.api.middleware :as mw]
             [clojure.tools.macro :as macro]))
 
-(defn- handle [handlers request]
-  (some #(% request) handlers))
-
 (defn routes
   "Create a Ring handler by combining several handlers into one."
   [& handlers]
   (let [handlers (seq (keep identity handlers))]
-    (routes/create nil nil {} (vec handlers) (partial handle handlers))))
+    (routes/create nil nil {} (vec handlers) (meta/routing handlers))))
 
 (defmacro defroutes
   "Define a Ring handler function from a sequence of routes.
@@ -34,7 +31,7 @@
   not satisfying compojure.api.routes/Routing -protocol."
   [& handlers]
   (let [handlers (keep identity handlers)]
-    (routes/create nil nil {} nil (partial handle handlers))))
+    (routes/create nil nil {} nil (meta/routing handlers))))
 
 (defmacro middleware
   "Wraps routes with given middlewares using thread-first macro.

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -534,6 +534,12 @@
   `(#'compojure.core/if-context
      ~(#'compojure.core/context-route path)
      ~route))
+
+(defn routing [handlers]
+  (if-let [handlers (seq (keep identity handlers))]
+    (apply some-fn handlers)
+    (constantly nil)))
+
 ;;
 ;; Api
 ;;
@@ -603,7 +609,7 @@
     (if context?
 
       ;; context
-      (let [form `(compojure.core/routes ~@body)
+      (let [form `(routing [~@body])
             form (if (seq letks) `(p/letk ~letks ~form) form)
             form (if (seq lets) `(let ~lets ~form) form)
             form (if (seq middleware) `((mw/compose-middleware ~middleware) ~form) form)

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -690,7 +690,6 @@
         ok? (fn [[status body]]
               (and (= status 200)
                    (= body response)))
-        not-ok? (comp not ok?)
         app (api
               (swagger-routes {:ui nil})
               (GET "/" [] ok)

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -1590,3 +1590,26 @@
                 (ok [a b])))]
     (app {:request-method :get, :uri "/a/b"}) => (contains {:body ["a" "b"]})
     (app {:request-method :get, :uri "/b/c"}) => (contains {:body ["b" "c"]})))
+
+(fact "nil routes are ignored"
+  (let [create-app (fn [{:keys [dev?]}]
+                     (context "/api" []
+                       (GET "/ping" [] (ok))
+                       (context "/db" []
+                         (if dev?
+                           (GET "/drop" [] (ok))))
+                       (if dev?
+                         (context "/dev" []
+                           (GET "/tools" [] (ok))))))]
+
+    (facts "with routes"
+      (let [app (create-app {:dev? true})]
+        (app {:request-method :get, :uri "/api/ping"}) => http/ok?
+        (app {:request-method :get, :uri "/api/db/drop"}) => http/ok?
+        (app {:request-method :get, :uri "/api/dev/tools"}) => http/ok?))
+
+    (facts "without routes"
+      (let [app (create-app {:dev? false})]
+        (app {:request-method :get, :uri "/api/ping"}) => http/ok?
+        (app {:request-method :get, :uri "/api/db/drop"}) => nil
+        (app {:request-method :get, :uri "/api/dev/tools"}) => nil))))


### PR DESCRIPTION
*Allow `nil` paths in routing
* also flatten's the call stack, removing 3 extra function call when running contexts. nice.