### PR TITLE
Resource async handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,17 @@
     * sent via `compojure.response/send` so [manifold](https://github.com/ztellman/manifold) `Deferred` and [core.async](https://github.com/clojure/core.async) `ManyToManyChannel` can be returned.
 
 ```clj
+(require '[compojure.api.sweet :refer :all])
 (require '[clojure.core.async :as a])
 (require '[manifold.deferred :as d])
 
 (resource
   {:summary "async resource"
    :get {:summary "normal ring async"
-         :async-handler (fn [request res _]
+         :async-handler (fn [request respond raise]
                           (future
                             (Thread/sleep 100)
-                            (res (ok {:hello "world"})))
+                            (respond (ok {:hello "world"})))
                           nil)}
    :put {:summary "core.async"
          :handler (fn [request]

--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ See [CHANGELOG](https://github.com/metosin/compojure-api/blob/master/CHANGELOG.m
     (ok {:message (str "Hello, " name)})))
 ```
 
+### Hello World, async
+
+```clj
+(require '[clojure.core.async :as a])
+
+(GET "/hello-async" []
+  :query-params [name :- String]
+  (a/go
+    (a/<! (a/timeout 500))
+    (ok {:message (str "Hello, " name)})))
+```
+
+<sub>* requires server to be run in [async mode](https://github.com/metosin/compojure-api/wiki/Async)</sub>
+
 ### Hello World, data-driven
 
 ```clj
@@ -51,22 +65,10 @@ See [CHANGELOG](https://github.com/metosin/compojure-api/blob/master/CHANGELOG.m
   {:get
    {:parameters {:query-params {:name String}
     :handler (fn [{{:keys [name]} :query-params}]
-               (ok {:message (str "Hello, " name)}))}}})
+               (a/go
+                 (a/<! (a/timeout 500))
+                 (ok {:message (str "Hello, " name)})}}})
 ```
-
-### Hello World, async
-
-```clj
-(require '[manifold.deferred :as d])
-
-(GET "/hello-async" []
-  :query-params [name :- String]
-  (d/future
-    (Thread/sleep 1000)
-    (ok {:message (str "Hello, " name)})))
-```
-
-<sub>* requires server to be run in [async mode](https://github.com/metosin/compojure-api/wiki/Async)</sub>
 
 ### Api with Schema & Swagger-docs
 

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
                  [clojure-msgpack "1.2.0" :exclusions [org.clojure/clojure]]
 
                  ;; http
-                 [ring/ring-core "1.6.0"]
+                 [ring/ring-core "1.6.1"]
                  [compojure "1.6.0" :exclusions [commons-codec]]
                  [metosin/ring-http-response "0.9.0"]
                  [metosin/ring-swagger "0.24.0"]
@@ -37,6 +37,7 @@
                              [funcool/codeina "0.5.0"]]
                    :dependencies [[org.clojure/clojure "1.8.0"]
                                   [slingshot "0.12.2"]
+                                  [org.clojure/core.async "0.3.442"]
                                   [peridot "0.4.4"]
                                   [javax.servlet/servlet-api "2.5"]
                                   [midje "1.9.0-alpha6"]

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,6 @@
                              [lein-ring "0.11.0"]
                              [funcool/codeina "0.5.0"]]
                    :dependencies [[org.clojure/clojure "1.8.0"]
-                                  [slingshot "0.12.2"]
                                   [org.clojure/core.async "0.3.442"]
                                   [peridot "0.4.4"]
                                   [javax.servlet/servlet-api "2.5"]

--- a/src/compojure/api/async.clj
+++ b/src/compojure/api/async.clj
@@ -7,7 +7,8 @@
 ;; those about unresolvable symbols. Keep this in mind when debugging the
 ;; definitions below.
 
-(muuntaja.util/when-ns 'manifold.deferred
+(muuntaja.util/when-ns
+  'manifold.deferred
   ;; Compojure is smart enough to get the success value out of deferred by
   ;; itself, but we want to catch the exceptions as well.
   (extend-protocol compojure.response/Sendable
@@ -15,7 +16,8 @@
     (send* [deferred request respond raise]
       (manifold.deferred/on-realized deferred #(response/send % request respond raise) raise))))
 
-(muuntaja.util/when-ns 'clojure.core.async
+(muuntaja.util/when-ns
+  'clojure.core.async
   (extend-protocol compojure.response/Sendable
     clojure.core.async.impl.channels.ManyToManyChannel
     (send* [channel request respond raise]

--- a/src/compojure/api/resource.clj
+++ b/src/compojure/api/resource.clj
@@ -88,7 +88,7 @@
            (as-> (coerce-request request info ks) $
                  (if async?
                    (handler $ #(compojure.response/send % $ respond-coerced raise) raise)
-                   (-> $ (handler) (compojure.response/send $ respond-coerced raise))))
+                   (compojure.response/send (handler $) $ respond-coerced raise)))
            (catch Throwable e
              (raise e))))))))
 

--- a/src/compojure/api/resource.clj
+++ b/src/compojure/api/resource.clj
@@ -4,6 +4,7 @@
             [ring.swagger.common :as rsc]
             [schema.core :as s]
             [plumbing.core :as p]
+            [compojure.api.async]
             [compojure.api.middleware :as mw]))
 
 (def ^:private +mappings+
@@ -75,6 +76,7 @@
        (when-let [[handler] (resolve-handler info path-info route request-method false)]
          (-> (coerce-request request info ks)
              handler
+             (compojure.response/render request)
              (coerce-response info request ks)))))
     ([{:keys [request-method path-info :compojure/route] :as request} respond raise]
      (let [request (if coercion (assoc-in request mw/coercion-request-ks coercion) request)

--- a/test/compojure/api/middleware_test.clj
+++ b/test/compojure/api/middleware_test.clj
@@ -4,8 +4,7 @@
             [midje.sweet :refer :all]
             [ring.util.http-response :refer [ok]]
             [ring.util.http-status :as status]
-            [ring.util.test]
-            [slingshot.slingshot :refer [throw+]])
+            [ring.util.test])
   (:import (java.io PrintStream ByteArrayOutputStream)))
 
 (defmacro without-err
@@ -26,7 +25,7 @@
     (fact
       (encode? nil
                {:body ?body
-                      :compojure.api.meta/serializable? ?serializable?}) => ?res)
+                :compojure.api.meta/serializable? ?serializable?}) => ?res)
     ?body ?serializable? ?res
     5 true true
     5 false false
@@ -71,8 +70,8 @@
 
   (with-out-str
     (without-err
-      (fact "Slingshot exception map type can be matched"
-        (let [handler (-> (fn [_] (throw+ {:type ::test} (RuntimeException. "kosh")))
+      (fact "Thrown ex-info type can be matched"
+        (let [handler (-> (fn [_] (throw (ex-info "kosh" {:type ::test})))
                           (wrap-exceptions (assoc-in default-options [:handlers ::test] (fn [ex _ _] {:status 500 :body "hello"}))))]
           (handler {}) => (contains {:status status/internal-server-error
                                      :body "hello"})))))

--- a/test/compojure/api/resource_test.clj
+++ b/test/compojure/api/resource_test.clj
@@ -172,7 +172,8 @@
         (handler {:request-method :post, :query-params {:x 1}} respond (promise))
         (deref respond 1000 :timeout) => (has-body {:total 10})))
 
-    (future-fact "testing the compojure.response/send*")))
+    (future-fact "response coercion from sync->async")
+    (future-fact "testing the compojure.response/send")))
 
 (fact "compojure-api routing integration"
   (let [app (context "/rest" []

--- a/test/compojure/api/resource_test.clj
+++ b/test/compojure/api/resource_test.clj
@@ -170,7 +170,9 @@
     (fact "operation-level sync handler can be called from async"
       (let [respond (promise)]
         (handler {:request-method :post, :query-params {:x 1}} respond (promise))
-        (deref respond 1000 :timeout) => (has-body {:total 10})))))
+        (deref respond 1000 :timeout) => (has-body {:total 10})))
+
+    (future-fact "testing the compojure.response/send*")))
 
 (fact "compojure-api routing integration"
   (let [app (context "/rest" []

--- a/test/compojure/api/resource_test.clj
+++ b/test/compojure/api/resource_test.clj
@@ -145,9 +145,9 @@
                                       (res (ok {:total x})))
                                     nil)
                    :get {:summary "operation-level async handler"
-                         :async-handler (fn [{{x :x} :query-params} res _]
+                         :async-handler (fn [{{x :x} :query-params} respond _]
                                           (future
-                                            (res (ok {:total (inc x)})))
+                                            (respond (ok {:total (inc x)})))
                                           nil)}
                    :post {:summary "operation-level sync handler"
                           :handler (fn [{{x :x} :query-params}]

--- a/test/compojure/api/resource_test.clj
+++ b/test/compojure/api/resource_test.clj
@@ -173,7 +173,7 @@
         (handler {:request-method :get, :query-params {:x 1}} respond (promise))
         (deref respond 1000 :timeout) => (has-body {:total 2})))
 
-    (fact "operation-level sync handler can be called from async"
+    (fact "sync handler can be called from async"
       (let [respond (promise)]
         (handler {:request-method :post, :query-params {:x 1}} respond (promise))
         (deref respond 1000 :timeout) => (has-body {:total 10}))
@@ -182,8 +182,8 @@
           (handler {:request-method :post, :query-params {:x -1}} (promise) raise)
           (throw (deref raise 1000 :timeout)) => response-validation-failed?)))
 
-    (fact "operation-level core.async"
-      (fact "3-arity"
+    (fact "core.async ManyToManyChannel"
+      (fact "works with 3-arity"
         (let [respond (promise)]
           (handler {:request-method :put, :query-params {:x 1}} respond (promise))
           (deref respond 1000 :timeout) => (has-body {:total 100}))
@@ -191,7 +191,7 @@
           (let [raise (promise)]
             (handler {:request-method :put, :query-params {:x -1}} (promise) raise)
             (throw (deref raise 1000 :timeout)) => response-validation-failed?)))
-      (fact "1-arity fails"
+      (fact "fails with 1-arity"
         (handler {:request-method :put, :query-params {:x 1}}) => (throws) #_(has-body {:total 100})
         (handler {:request-method :put, :query-params {:x -1}}) => (throws) #_response-validation-failed?))))
 

--- a/test/compojure/api/resource_test.clj
+++ b/test/compojure/api/resource_test.clj
@@ -141,8 +141,8 @@
                    :responses {200 {:schema {:total (s/constrained Long pos? 'pos)}}}
                    :summary "top-level async handler"
                    :async-handler (fn [{{x :x} :query-params} res _]
-                              (future
-                                (res (ok {:total x})))
+                                    (future
+                                      (res (ok {:total x})))
                                     nil)
                    :get {:summary "operation-level async handler"
                          :async-handler (fn [{{x :x} :query-params} res _]
@@ -164,9 +164,9 @@
         (handler {:query-params {:x -1}} (promise) res-raise)
         (handler {:query-params {:x "x"}} (promise) req-raise)
 
-    (deref respond 1000 :timeout) => (has-body {:total 1})
-    (throw (deref res-raise 1000 :timeout)) => response-validation-failed?
-    (throw (deref req-raise 1000 :timeout)) => request-validation-failed?))
+        (deref respond 1000 :timeout) => (has-body {:total 1})
+        (throw (deref res-raise 1000 :timeout)) => response-validation-failed?
+        (throw (deref req-raise 1000 :timeout)) => request-validation-failed?))
 
     (fact "operation-level async handler"
       (let [respond (promise)]
@@ -184,16 +184,16 @@
 
     (fact "operation-level core.async"
       (fact "3-arity"
-      (let [respond (promise)]
-        (handler {:request-method :put, :query-params {:x 1}} respond (promise))
-        (deref respond 1000 :timeout) => (has-body {:total 100}))
-      (fact "response coercion works"
-        (let [raise (promise)]
-          (handler {:request-method :put, :query-params {:x -1}} (promise) raise)
+        (let [respond (promise)]
+          (handler {:request-method :put, :query-params {:x 1}} respond (promise))
+          (deref respond 1000 :timeout) => (has-body {:total 100}))
+        (fact "response coercion works"
+          (let [raise (promise)]
+            (handler {:request-method :put, :query-params {:x -1}} (promise) raise)
             (throw (deref raise 1000 :timeout)) => response-validation-failed?)))
-      (fact "1-arity"
-        (handler {:request-method :put, :query-params {:x 1}}) => (has-body {:total 100})
-        (handler {:request-method :put, :query-params {:x -1}}) => response-validation-failed?))))
+      (fact "1-arity fails"
+        (handler {:request-method :put, :query-params {:x 1}}) => (throws) #_(has-body {:total 100})
+        (handler {:request-method :put, :query-params {:x -1}}) => (throws) #_response-validation-failed?))))
 
 (fact "compojure-api routing integration"
   (let [app (context "/rest" []


### PR DESCRIPTION
related to #297

* **BREAKING**: `resource` separates 1-arity `:handler` and 3-arity `:async-handler`. Rules:
  * if resource is called with 1-arity, `:handler` is used, sent via `compojure.response/render`
  * if resource is called with 3-arity, `:async-handler` is used, with fallback to `:handler`.
    * sent via `compojure.response/send` so [manifold](https://github.com/ztellman/manifold) `Deferred` and [core.async](https://github.com/clojure/core.async) `ManyToManyChannel` can be returned.

```clj
(require '[compojure.api.sweet :refer :all])
(require '[clojure.core.async :as a])
(require '[manifold.deferred :as d])

(resource
  {:summary "async resource"
   :get {:summary "normal ring async"
         :async-handler (fn [request respond raise]
                          (future
                            (Thread/sleep 100)
                            (respond (ok {:hello "world"})))
                          nil)}
   :put {:summary "core.async"
         :handler (fn [request]
                    (a/go
                      (a/<! (a/timeout 100))
                      (ok {:hello "world"})))}
   :post {:summary "manifold"
          :handler (fn [request]
                     (d/future
                       (Thread/sleep 100)
                       (ok {:hello "world"})))}})
```

* updated deps:

```clj
[ring/ring-core "1.6.1"] is available but we use "1.6.0"
```