### PR TITLE
Docstring and tests for async resource

### DIFF
--- a/src/compojure/api/resource.clj
+++ b/src/compojure/api/resource.clj
@@ -160,9 +160,14 @@
     2.2) :responses are merged into operation :responses (operation can fully override them)
     2.3) all others (:produces, :consumes, :summary,...) are deep-merged by compojure-api
 
-  3) special key `:handler` either under operations or at top-level. Value should be a
-  ring-handler function, responsible for the actual request processing. Handler lookup
-  order is the following: operations-level, top-level.
+  3) special keys `:handler` and/or `:async-handler` either under operations or at top-level.
+  They should be 1-ary and 3-ary Ring handler functions, respectively, that are responsible
+  for the actual request processing. Handler lookup order is the following:
+
+    3.1) If called asynchronously, operations-level :async-handler
+    3.2) Operations-level :handler
+    3.3) If called asynchronously, top-level :async-handler
+    3.4) Top-level :handler
 
   4) request-coercion is applied once, using deep-merged parameters for a given
   operation or resource-level if only resource-level handler is defined.
@@ -192,4 +197,3 @@
         childs (create-childs info)
         handler (create-handler info)]
     (routes/create nil nil root-info childs handler)))
-

--- a/src/compojure/api/resource.clj
+++ b/src/compojure/api/resource.clj
@@ -85,7 +85,7 @@
           (coerce-response info request ks)))))
 
 (defn- handle-async [info coercion {:keys [request-method path-info :compojure/route] :as request} respond raise]
-  (when-let [[raw-handler async?] (resolve-handler info path-info route request-method true)]
+  (if-let [[raw-handler async?] (resolve-handler info path-info route request-method true)]
     (let [request (if coercion (assoc-in request mw/coercion-request-ks coercion) request)
           ks (if (contains? info request-method) [request-method] [])
           respond-coerced (fn [response]
@@ -99,7 +99,8 @@
                 (handler $ #(compojure.response/send % $ respond-coerced raise) raise)
                 (compojure.response/send (handler $) $ respond-coerced raise)))
         (catch Throwable e
-          (raise e))))))
+          (raise e))))
+    (respond nil)))
 
 (defn- create-handler [{:keys [coercion] :as info}]
   (fn

--- a/test/compojure/api/test_utils.clj
+++ b/test/compojure/api/test_utils.clj
@@ -55,6 +55,13 @@
       (throw (Exception. (str "Timeout while waiting for the request handler. "
                               request))))))
 
+(defn call
+  "Call handler synchronously or asynchronously depending on *async?*."
+  [handler request]
+  (if *async?*
+    (call-async handler request)
+    (handler request)))
+
 (defn raw-get* [app uri & [params headers]]
   (let [{{:keys [status body headers]} :response}
         (-> (cond->> app *async?* (partial call-async))


### PR DESCRIPTION
This is to address the remaining concerns in issue #297.

* explain `:handler` and `:async-handler` in the `resource` docstring
* run resource tests both in sync and async mode
* fix the bug found by running the tests