### PR TITLE
Implement a function to list static contexts

### DIFF
--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -151,7 +151,7 @@
       "  (ok))")))
 
 (defmethod restructure-param :no-doc [_ v acc]
-  (update-in acc [:info] assoc ::no-doc v))
+  (update-in acc [:info] assoc :no-doc v))
 
 ;;
 ;; swagger
@@ -189,7 +189,6 @@
       "    (created (path-for ::user {:id (random-int)}))))")))
 
 (defmethod restructure-param :name [_ v acc]
-  ;; :x-name could be possibly moved from [:info :public] into [:info]
   (update-in acc [:info :public] assoc :x-name v))
 
 ;;
@@ -607,7 +606,7 @@
 
         static-context? (and static? context?)
         info (cond-> info
-               static-context? (assoc ::static-context? static-context?))
+               static-context? (assoc :static-context? static-context?))
 
         _ (assert (nil? swagger) ":swagger is deprecated with 2.0.0, use [:info :public] instead")
 

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -68,7 +68,7 @@
       "  (ok))")))
 
 (defmethod restructure-param :summary [k v acc]
-  (update-in acc [:swagger] assoc k v))
+  (update-in acc [:info :public] assoc k v))
 
 ;;
 ;; description
@@ -84,7 +84,7 @@
       "  (ok))")))
 
 (defmethod restructure-param :description [k v acc]
-  (update-in acc [:swagger] assoc k v))
+  (update-in acc [:info :public] assoc k v))
 
 ;;
 ;; OperationId
@@ -102,7 +102,7 @@
       "  (ok))")))
 
 (defmethod restructure-param :operationId [k v acc]
-  (update-in acc [:swagger] assoc k v))
+  (update-in acc [:info :public] assoc k v))
 
 ;;
 ;; Consumes
@@ -119,7 +119,7 @@
       "  (ok))")))
 
 (defmethod restructure-param :consumes [k v acc]
-  (update-in acc [:swagger] assoc k v))
+  (update-in acc [:info :public] assoc k v))
 
 ;;
 ;; Provides
@@ -136,7 +136,7 @@
       "  (ok))")))
 
 (defmethod restructure-param :produces [k v acc]
-  (update-in acc [:swagger] assoc k v))
+  (update-in acc [:info :public] assoc k v))
 
 ;;
 ;; no-doc
@@ -151,7 +151,8 @@
       "  (ok))")))
 
 (defmethod restructure-param :no-doc [_ v acc]
-  (update-in acc [:swagger] assoc :x-no-doc v))
+  ;; XXX(miikka) This could be moved from [:info :public] into [:info]
+  (update-in acc [:info :public] assoc :x-no-doc v))
 
 ;;
 ;; swagger
@@ -170,7 +171,7 @@
       "  (ok))")))
 
 (defmethod restructure-param :swagger [_ swagger acc]
-  (assoc-in acc [:swagger :swagger] swagger))
+  (assoc-in acc [:info :public :swagger] swagger))
 
 ;;
 ;; name
@@ -189,7 +190,8 @@
       "    (created (path-for ::user {:id (random-int)}))))")))
 
 (defmethod restructure-param :name [_ v acc]
-  (update-in acc [:swagger] assoc :x-name v))
+  ;; :x-name could be possibly moved from [:info :public] into [:info]
+  (update-in acc [:info :public] assoc :x-name v))
 
 ;;
 ;; tags
@@ -204,7 +206,7 @@
       "  (ok))")))
 
 (defmethod restructure-param :tags [_ tags acc]
-  (update-in acc [:swagger :tags] (comp set into) tags))
+  (update-in acc [:info :public :tags] (comp set into) tags))
 
 ;;
 ;; return
@@ -221,7 +223,7 @@
 (defmethod restructure-param :return [_ schema acc]
   (let [response (convert-return schema)]
     (-> acc
-        (update-in [:swagger :responses] (fnil conj []) response)
+        (update-in [:info :public :responses] (fnil conj []) response)
         (update-in [:responses] (fnil conj []) response))))
 
 ;;
@@ -246,7 +248,7 @@
 
 (defmethod restructure-param :responses [_ responses acc]
   (-> acc
-      (update-in [:swagger :responses] (fnil conj []) responses)
+      (update-in [:info :public :responses] (fnil conj []) responses)
       (update-in [:responses] (fnil conj []) responses)))
 
 ;;
@@ -265,7 +267,7 @@
 (defmethod restructure-param :body [_ [value schema] acc]
   (-> acc
       (update-in [:lets] into [value (src-coerce! schema :body-params :body false)])
-      (assoc-in [:swagger :parameters :body] schema)))
+      (assoc-in [:info :public :parameters :body] schema)))
 
 ;;
 ;; query
@@ -283,7 +285,7 @@
 (defmethod restructure-param :query [_ [value schema] acc]
   (-> acc
       (update-in [:lets] into [value (src-coerce! schema :query-params :string)])
-      (assoc-in [:swagger :parameters :query] schema)))
+      (assoc-in [:info :public :parameters :query] schema)))
 
 ;;
 ;; headers
@@ -301,7 +303,7 @@
 (defmethod restructure-param :headers [_ [value schema] acc]
   (-> acc
       (update-in [:lets] into [value (src-coerce! schema :headers :string)])
-      (assoc-in [:swagger :parameters :header] schema)))
+      (assoc-in [:info :public :parameters :header] schema)))
 
 ;;
 ;; body-params
@@ -320,7 +322,7 @@
   (let [schema (strict (fnk-schema body-params))]
     (-> acc
         (update-in [:letks] into [body-params (src-coerce! schema :body-params :body)])
-        (assoc-in [:swagger :parameters :body] schema))))
+        (assoc-in [:info :public :parameters :body] schema))))
 
 ;;
 ;; form-params
@@ -340,8 +342,8 @@
   (let [schema (strict (fnk-schema form-params))]
     (-> acc
         (update-in [:letks] into [form-params (src-coerce! schema :form-params :string)])
-        (update-in [:swagger :parameters :formData] st/merge schema)
-        (assoc-in [:swagger :consumes] ["application/x-www-form-urlencoded"]))))
+        (update-in [:info :public :parameters :formData] st/merge schema)
+        (assoc-in [:info :public :consumes] ["application/x-www-form-urlencoded"]))))
 
 ;;
 ;; multipart-params
@@ -365,8 +367,8 @@
   (let [schema (strict (fnk-schema params))]
     (-> acc
         (update-in [:letks] into [params (src-coerce! schema :multipart-params :string)])
-        (update-in [:swagger :parameters :formData] st/merge schema)
-        (assoc-in [:swagger :consumes] ["multipart/form-data"]))))
+        (update-in [:info :public :parameters :formData] st/merge schema)
+        (assoc-in [:info :public :consumes] ["multipart/form-data"]))))
 
 ;;
 ;; header-params
@@ -385,7 +387,7 @@
   (let [schema (fnk-schema header-params)]
     (-> acc
         (update-in [:letks] into [header-params (src-coerce! schema :headers :string)])
-        (assoc-in [:swagger :parameters :header] schema))))
+        (assoc-in [:info :public :parameters :header] schema))))
 
 ;;
 ;; :query-params
@@ -404,7 +406,7 @@
   (let [schema (fnk-schema query-params)]
     (-> acc
         (update-in [:letks] into [query-params (src-coerce! schema :query-params :string)])
-        (assoc-in [:swagger :parameters :query] schema))))
+        (assoc-in [:info :public :parameters :query] schema))))
 
 ;;
 ;; path-params
@@ -423,7 +425,7 @@
   (let [schema (fnk-schema path-params)]
     (-> acc
         (update-in [:letks] into [path-params (src-coerce! schema :route-params :string)])
-        (assoc-in [:swagger :parameters :path] schema))))
+        (assoc-in [:info :public :parameters :path] schema))))
 
 ;;
 ;; middleware
@@ -566,12 +568,17 @@
               (RuntimeException.
                 (str "unknown compojure destruction syntax: " arg))))))
 
-(defn merge-parameters
-  "Merge parameters at runtime to allow usage of runtime-paramers with route-macros."
+(defn- merge-public-parameters
   [{:keys [responses swagger] :as parameters}]
   (cond-> parameters
-          (seq responses) (assoc :responses (apply merge responses))
-          swagger (-> (dissoc :swagger) (rsc/deep-merge swagger))))
+    (seq responses) (assoc :responses (apply merge responses))
+    swagger (-> (dissoc :swagger) (rsc/deep-merge swagger))))
+
+(defn merge-parameters
+  "Merge parameters at runtime to allow usage of runtime-paramers with route-macros."
+  [info]
+  (cond-> info
+    (contains? info :public) (update :public merge-public-parameters)))
 
 (defn- route-args? [arg]
   (not= arg []))
@@ -584,6 +591,7 @@
                 letks
                 responses
                 middleware
+                info
                 swagger
                 body]} (reduce
                          (fn [acc [k v]]
@@ -592,11 +600,13 @@
                           :letks []
                           :responses nil
                           :middleware []
-                          :swagger {}
+                          :info {}
                           :body body}
                          options)
 
         static? (not (or dynamic? (route-args? route-arg) (seq lets) (seq letks)))
+
+        _ (assert (nil? swagger) ":swagger is deprecated with 2.0.0, use [:info :public] instead")
 
         ;; response coercion middleware, why not just code?
         middleware (if (seq responses) (conj middleware `[coerce/body-coercer-middleware (merge ~@responses)]) middleware)]
@@ -624,7 +634,7 @@
         `(routes/map->Route
            {:path ~path-string
             :method ~method
-            :info (merge-parameters ~swagger)
+            :info (merge-parameters ~info)
             :childs ~childs
             :handler ~form}))
 
@@ -638,5 +648,5 @@
         `(routes/map->Route
            {:path ~path-string
             :method ~method
-            :info (merge-parameters ~swagger)
+            :info (merge-parameters ~info)
             :handler ~form})))))

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -151,8 +151,7 @@
       "  (ok))")))
 
 (defmethod restructure-param :no-doc [_ v acc]
-  ;; XXX(miikka) This could be moved from [:info :public] into [:info]
-  (update-in acc [:info :public] assoc :x-no-doc v))
+  (update-in acc [:info] assoc ::no-doc v))
 
 ;;
 ;; swagger

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -605,6 +605,10 @@
 
         static? (not (or dynamic? (route-args? route-arg) (seq lets) (seq letks)))
 
+        static-context? (and static? context?)
+        info (cond-> info
+               static-context? (assoc ::static-context? static-context?))
+
         _ (assert (nil? swagger) ":swagger is deprecated with 2.0.0, use [:info :public] instead")
 
         ;; response coercion middleware, why not just code?

--- a/src/compojure/api/resource.clj
+++ b/src/compojure/api/resource.clj
@@ -74,7 +74,7 @@
       (routes/map->Route
         {:path "/"
          :method method
-         :info (swaggerize info)}))
+         :info {:public (swaggerize info)}}))
     (select-keys info (:methods +mappings+))))
 
 (defn- handle-sync [info coercion {:keys [request-method path-info :compojure/route] :as request}]
@@ -201,6 +201,6 @@
         childs (create-childs info)
         handler (create-handler info)]
     (routes/map->Route
-      {:info root-info
+      {:info {:public root-info}
        :childs childs
        :handler handler})))

--- a/src/compojure/api/routes.clj
+++ b/src/compojure/api/routes.clj
@@ -52,7 +52,7 @@
   ([handler]
    (get-static-context-routes handler nil))
   ([handler options]
-   (filter (fn [[_ _ info]] (get info :compojure.api.meta/static-context?))
+   (filter (fn [[_ _ info]] (get info :static-context?))
            (get-routes handler options))))
 
 (defn- realize-childs [route]
@@ -136,7 +136,7 @@
   {:paths
    (reduce
      (fn [acc [path method info]]
-       (if-not (true? (:compojure.api.meta/no-doc info))
+       (if-not (true? (:no-doc info))
          (let [public-info (get info :public {})]
            (update-in
             acc [path method]

--- a/src/compojure/api/routes.clj
+++ b/src/compojure/api/routes.clj
@@ -48,6 +48,13 @@
        (update-in route [0] (fn [uri] (if (str/blank? uri) "/" uri))))
      (-get-routes handler options))))
 
+(defn get-static-context-routes
+  ([handler]
+   (get-static-context-routes handler nil))
+  ([handler options]
+   (filter (fn [[_ _ info]] (get info :compojure.api.meta/static-context?))
+           (get-routes handler options))))
+
 (defn- realize-childs [route]
   (update route :childs #(if (instance? IDeref %) @% %)))
 

--- a/src/compojure/api/routes.clj
+++ b/src/compojure/api/routes.clj
@@ -129,11 +129,12 @@
   {:paths
    (reduce
      (fn [acc [path method info]]
-       (update-in
-         acc [path method]
-         (fn [old-info]
-           (let [info (or old-info info)]
-             (ensure-path-parameters path info)))))
+       (let [public-info (get info :public {})]
+         (update-in
+          acc [path method]
+          (fn [old-info]
+            (let [public-info (or old-info public-info)]
+              (ensure-path-parameters path public-info))))))
      (linked/map)
      routes)})
 

--- a/src/compojure/api/swagger.clj
+++ b/src/compojure/api/swagger.clj
@@ -24,9 +24,7 @@
           first))
 
 (defn transform-operations [swagger]
-  (->> swagger
-       (swagger2/transform-operations routes/non-nil-routes)
-       (swagger2/transform-operations routes/strip-no-doc-endpoints)))
+  (swagger2/transform-operations routes/non-nil-routes swagger))
 
 (defn swagger-ui [options]
   (assert (map? options) "Since 1.2.0, compojure.api.swagger/swagger-ui takes just one map as argument, with `:path` for the path.")

--- a/test/compojure/api/routes_test.clj
+++ b/test/compojure/api/routes_test.clj
@@ -74,7 +74,7 @@
 
     (fact "routes can be extracted at runtime"
       (routes/get-routes app)
-      => [["/swagger.json" :get {:public {:x-no-doc true, :x-name :compojure.api.swagger/swagger}}]
+      => [["/swagger.json" :get {:compojure.api.meta/no-doc true, :public {:x-name :compojure.api.swagger/swagger}}]
           ["/api/:version/ping" :get {:public {:parameters {:path {:version String, s/Keyword s/Any}}}}]
           ["/api/:version/ping" :post {:public {:parameters {:path {:version String, s/Keyword s/Any}}}}]
           ["/api/:version/hello" :get {:public  {:parameters {:query {:name String, s/Keyword s/Any}
@@ -120,7 +120,7 @@
 
     (fact "routes can be extracted at runtime"
       (routes/get-routes app)
-      => [["/swagger.json" :get {:public {:x-no-doc true, :x-name :compojure.api.swagger/swagger}}]
+      => [["/swagger.json" :get {:compojure.api.meta/no-doc true, :public {:x-name :compojure.api.swagger/swagger}}]
           ["/api/:version/[]" :get {:public {:parameters {:path {:version String, s/Keyword s/Any}}}}]])
 
     (fact "swagger-docs can be generated"

--- a/test/compojure/api/routes_test.clj
+++ b/test/compojure/api/routes_test.clj
@@ -96,7 +96,7 @@
 
 (facts "following var-routes, #219"
   (let [routes (context "/api" [] #'more-routes)]
-    (routes/get-routes routes) => [["/api/more" :get {}]]))
+    (routes/get-routes routes) => [["/api/more" :get {:compojure.api.meta/static-context? true}]]))
 
 (facts "dynamic routes"
   (let [more-routes (fn [version]
@@ -164,3 +164,12 @@
     (reset! endpoint? false)
     (fact "the endpoint does not exist"
       (app {:request-method :get :uri "/api/ping"}) => nil)))
+
+(fact "listing static context routes"
+  (let [app (routes
+              (context "/static" []
+                (GET "/ping" [] (ok "pong")))
+              (context "/dynamic" req
+                (GET "/ping" [] (ok "pong"))))]
+    (routes/get-static-context-routes app)
+    => [["/static/ping" :get {:compojure.api.meta/static-context? true}]]))

--- a/test/compojure/api/routes_test.clj
+++ b/test/compojure/api/routes_test.clj
@@ -74,7 +74,7 @@
 
     (fact "routes can be extracted at runtime"
       (routes/get-routes app)
-      => [["/swagger.json" :get {:compojure.api.meta/no-doc true, :public {:x-name :compojure.api.swagger/swagger}}]
+      => [["/swagger.json" :get {:no-doc true, :public {:x-name :compojure.api.swagger/swagger}}]
           ["/api/:version/ping" :get {:public {:parameters {:path {:version String, s/Keyword s/Any}}}}]
           ["/api/:version/ping" :post {:public {:parameters {:path {:version String, s/Keyword s/Any}}}}]
           ["/api/:version/hello" :get {:public  {:parameters {:query {:name String, s/Keyword s/Any}
@@ -96,7 +96,7 @@
 
 (facts "following var-routes, #219"
   (let [routes (context "/api" [] #'more-routes)]
-    (routes/get-routes routes) => [["/api/more" :get {:compojure.api.meta/static-context? true}]]))
+    (routes/get-routes routes) => [["/api/more" :get {:static-context? true}]]))
 
 (facts "dynamic routes"
   (let [more-routes (fn [version]
@@ -120,7 +120,7 @@
 
     (fact "routes can be extracted at runtime"
       (routes/get-routes app)
-      => [["/swagger.json" :get {:compojure.api.meta/no-doc true, :public {:x-name :compojure.api.swagger/swagger}}]
+      => [["/swagger.json" :get {:no-doc true, :public {:x-name :compojure.api.swagger/swagger}}]
           ["/api/:version/[]" :get {:public {:parameters {:path {:version String, s/Keyword s/Any}}}}]])
 
     (fact "swagger-docs can be generated"
@@ -172,4 +172,4 @@
               (context "/dynamic" req
                 (GET "/ping" [] (ok "pong"))))]
     (routes/get-static-context-routes app)
-    => [["/static/ping" :get {:compojure.api.meta/static-context? true}]]))
+    => [["/static/ping" :get {:static-context? true}]]))

--- a/test/compojure/api/routes_test.clj
+++ b/test/compojure/api/routes_test.clj
@@ -74,14 +74,14 @@
 
     (fact "routes can be extracted at runtime"
       (routes/get-routes app)
-      => [["/swagger.json" :get {:x-no-doc true, :x-name :compojure.api.swagger/swagger}]
-          ["/api/:version/ping" :get {:parameters {:path {:version String, s/Keyword s/Any}}}]
-          ["/api/:version/ping" :post {:parameters {:path {:version String, s/Keyword s/Any}}}]
-          ["/api/:version/hello" :get {:parameters {:query {:name String, s/Keyword s/Any}
-                                                    :path {:version String, s/Keyword s/Any}}
-                                       :responses {200 {:description "", :schema {:message String}}}
-                                       :summary "cool ping"}]
-          ["/api/:version/more" :get {:parameters {:path {:version String, s/Keyword s/Any}}}]])
+      => [["/swagger.json" :get {:public {:x-no-doc true, :x-name :compojure.api.swagger/swagger}}]
+          ["/api/:version/ping" :get {:public {:parameters {:path {:version String, s/Keyword s/Any}}}}]
+          ["/api/:version/ping" :post {:public {:parameters {:path {:version String, s/Keyword s/Any}}}}]
+          ["/api/:version/hello" :get {:public  {:parameters {:query {:name String, s/Keyword s/Any}
+                                                              :path {:version String, s/Keyword s/Any}}
+                                                 :responses {200 {:description "", :schema {:message String}}}
+                                                 :summary "cool ping"}}]
+          ["/api/:version/more" :get {:public {:parameters {:path {:version String, s/Keyword s/Any}}}}]])
 
     (fact "swagger-docs can be generated"
       (-> app get-spec :paths keys)
@@ -120,8 +120,8 @@
 
     (fact "routes can be extracted at runtime"
       (routes/get-routes app)
-      => [["/swagger.json" :get {:x-no-doc true, :x-name :compojure.api.swagger/swagger}]
-          ["/api/:version/[]" :get {:parameters {:path {:version String, s/Keyword s/Any}}}]])
+      => [["/swagger.json" :get {:public {:x-no-doc true, :x-name :compojure.api.swagger/swagger}}]
+          ["/api/:version/[]" :get {:public {:parameters {:path {:version String, s/Keyword s/Any}}}}]])
 
     (fact "swagger-docs can be generated"
       (-> app get-spec :paths keys)

--- a/test/compojure/api/sweet_test.clj
+++ b/test/compojure/api/sweet_test.clj
@@ -70,8 +70,7 @@
 
     (extract-paths app)
 
-    => {"/swagger.json" {:get {:x-name :compojure.api.swagger/swagger,
-                               :x-no-doc true}}
+    => {"/swagger.json" {:get {:x-name :compojure.api.swagger/swagger}}
         "/ping" {:get {}}
         "/api/ping" {:get {}}
         "/api/bands" {:get {:x-name :bands

--- a/test/compojure/api/test_utils.clj
+++ b/test/compojure/api/test_utils.clj
@@ -119,7 +119,7 @@
 ;;
 
 (defn extract-paths [app]
-  (-> app routes/get-routes routes/ring-swagger-paths :paths))
+  (-> app routes/get-routes routes/all-paths))
 
 (defn get-spec [app]
   (let [[status spec] (get* app "/swagger.json" {})]


### PR DESCRIPTION
This is to help with the migration to 2.0.

Implementation details:

* Now Route's `info` field contains Swagger data. This is moved under `:public` in `info`.
* The no-doc metadata is moved to the top level of `info`
* `info` top-level now has `:compojure.api.meta/static-context? true` if the route is affected by the static context optimization.

This is related to #300.