### PR TITLE
Use optimised merge for merging endpoint parameters

### DIFF
--- a/src/compojure/api/common.clj
+++ b/src/compojure/api/common.clj
@@ -34,3 +34,10 @@
   [pred coll]
   [(seq (filter pred coll))
    (seq (remove pred coll))])
+
+(defn merge-vector
+  "Merges vector elements, optimized for 1 arity (x10 faster than merge)."
+  [v]
+  (if (get v 1)
+    (apply merge v)
+    (get v 0)))

--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -11,7 +11,8 @@
             [compojure.api.coerce :as coerce]
             [compojure.api.help :as help]
             compojure.core
-            compojure.api.compojure-compat))
+            compojure.api.compojure-compat
+            [compojure.api.common :as common]))
 
 (def +compojure-api-request+
   "lexically bound ring-request for handlers."
@@ -570,7 +571,7 @@
   "Merge parameters at runtime to allow usage of runtime-paramers with route-macros."
   [{:keys [responses swagger] :as parameters}]
   (cond-> parameters
-          (seq responses) (assoc :responses (apply merge responses))
+          (seq responses) (assoc :responses (common/merge-vector responses))
           swagger (-> (dissoc :swagger) (rsc/deep-merge swagger))))
 
 (defn- route-args? [arg]
@@ -599,7 +600,7 @@
         static? (not (or dynamic? (route-args? route-arg) (seq lets) (seq letks)))
 
         ;; response coercion middleware, why not just code?
-        middleware (if (seq responses) (conj middleware `[coerce/body-coercer-middleware (merge ~@responses)]) middleware)]
+        middleware (if (seq responses) (conj middleware `[coerce/body-coercer-middleware (common/merge-vector ~responses)]) middleware)]
 
     (if context?
 

--- a/test/compojure/api/common_test.clj
+++ b/test/compojure/api/common_test.clj
@@ -21,3 +21,8 @@
     (common/extract-parameters [:a 1] false) => [{:a 1} nil]
     (common/extract-parameters [{:a 1} {:b 2}] false) => [{:a 1} [{:b 2}]]
     (common/extract-parameters [:a 1 {:b 2}] false) => [{:a 1} [{:b 2}]]))
+
+(fact "merge-vector"
+  (common/merge-vector nil) => nil
+  (common/merge-vector [{:a 1}]) => {:a 1}
+  (common/merge-vector [{:a 1} {:b 2}]) => {:a 1 :b 2})


### PR DESCRIPTION
Eastwood gives errors from 1-arity merge:

```clj
src/test_eastwood/core.clj:1:1: suspicious-expression: merge called with 1 args. 
(merge map) always returns map.  Perhaps there are misplaced parentheses?
```

use optimised `merge-vector` instead, actually 10x faster for the default case:

```clj
(criterium.core/quick-bench
  (common/merge-vector [{:a 1}]))
; Evaluation count : 84624984 in 6 samples of 14104164 calls.
; Execution time mean : 5.661312 ns
; Execution time std-deviation : 0.305832 ns
; Execution time lower quantile : 5.152271 ns ( 2.5%)
; Execution time upper quantile : 5.942857 ns (97.5%)
; Overhead used : 1.782284 ns

(criterium.core/quick-bench
  (apply merge [{:a 1}]))
; Evaluation count : 8572680 in 6 samples of 1428780 calls.
; Execution time mean : 68.158156 ns
; Execution time std-deviation : 2.062488 ns
; Execution time lower quantile : 65.875315 ns ( 2.5%)
; Execution time upper quantile : 70.444445 ns (97.5%)
; Overhead used : 1.782284 ns
```