### PR TITLE
Drop direct support for YAML & Msgpack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## UNRELEASED
+
+* drop direct support for `application/yaml` & `application/msgpack. If you want to add them back, you need to manually add the dependencies below and configure Muuntaja to handle those:
+
+```clj
+(require '[muuntaja.core :as muuntaja])
+(require '[muuntaja.format.yaml :as yaml-format])
+(require '[muuntaja.format.msgpack :as msgpack-format])
+
+(api
+  {:formats (-> muuntaja/default-options)
+                (yaml-format/with-yaml-format)
+                (msgpack-format/with-msgpack-format)}
+  ...)
+```
+
+* dropped dependencies:
+
+```clj
+[circleci/clj-yaml "0.5.6"]
+[clojure-msgpack "1.2.0"]
+```
+
 ## 2.0.0-alpha6 (26.7.2017)
 
 * spec coericon also calls `s/unform` after `s/conform`, e.g. specs like `(s/or :int spec/int? :keyword spec/keyword?)` work now too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## UNRELEASED
 
-* drop direct support for `application/yaml` & `application/msgpack. If you want to add them back, you need to manually add the dependencies below and configure Muuntaja to handle those:
+* drop direct support for `application/yaml` & `application/msgpack`. If you want to add them back, you need to manually add the dependencies below and configure Muuntaja to handle those:
 
 ```clj
 (require '[muuntaja.core :as muuntaja])
@@ -10,7 +10,7 @@
 (api
   {:formats (-> muuntaja/default-options)
                 (yaml-format/with-yaml-format)
-                (msgpack-format/with-msgpack-format)}
+                (msgpack-format/with-msgpack-format))}
   ...)
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Stuff on top of [Compojure](https://github.com/weavejester/compojure) for making
 - [Schema](https://github.com/Prismatic/schema) & [clojure.spec](https://clojure.org/about/spec) (2.0.0) for input & output data coercion
 - [Swagger](http://swagger.io/) for api documentation, via [ring-swagger](https://github.com/metosin/ring-swagger) & [spec-tools](https://github.com/metosin/spec-tools)
 - [Async](https://github.com/metosin/compojure-api/wiki/Async) with async-ring, [manifold](https://github.com/ztellman/manifold) and [core.async](https://github.com/clojure/core.async) (2.0.0)
-- Client negotiable formats: [JSON](http://www.json.org/), [EDN](https://github.com/edn-format/edn) & [Transit](https://github.com/cognitect/transit-format)
+- Client negotiable formats: [JSON](http://www.json.org/), [EDN](https://github.com/edn-format/edn) & [Transit](https://github.com/cognitect/transit-format), optionally [YAML](http://yaml.org/) and [MessagePack](http://msgpack.org/)
 - Data-driven [resources](https://github.com/metosin/compojure-api/wiki/Resources-and-Liberator)
 - [Bi-directional](https://github.com/metosin/compojure-api/wiki/Routing#bi-directional-routing) routing
 - Bundled middleware for common api behavior ([exception handling](https://github.com/metosin/compojure-api/wiki/Exception-handling), parameters & formats)

--- a/project.clj
+++ b/project.clj
@@ -11,13 +11,7 @@
                  [prismatic/plumbing "0.5.4"]
                  [org.tobereplaced/lettercase "1.0.0"]
                  [frankiesardo/linked "1.2.9"]
-
-                 ;; api-formatters
                  [metosin/muuntaja "0.3.2"]
-                 [circleci/clj-yaml "0.5.6"]
-                 [clojure-msgpack "1.2.0" :exclusions [org.clojure/clojure]]
-
-                 ;; http
                  [ring/ring-core "1.6.2"]
                  [compojure "1.6.0" :exclusions [commons-codec]]
                  [metosin/ring-http-response "0.9.0"]

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -12,8 +12,6 @@
 
             [muuntaja.middleware]
             [muuntaja.core :as m]
-            [muuntaja.format.yaml :as yaml-format]
-            [muuntaja.format.msgpack :as msgpack-format]
 
             [ring.swagger.common :as rsc]
             [ring.swagger.middleware :as rsm]
@@ -126,10 +124,7 @@
   (or (:compojure.api.meta/serializable? response)
       (coll? (:body response))))
 
-(def muuntaja-options
-  (-> m/default-options
-      (yaml-format/with-yaml-format)
-      (msgpack-format/with-msgpack-format)))
+(def muuntaja-options m/default-options)
 
 (defn create-muuntaja
   ([]

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -124,11 +124,9 @@
   (or (:compojure.api.meta/serializable? response)
       (coll? (:body response))))
 
-(def muuntaja-options m/default-options)
-
 (defn create-muuntaja
   ([]
-   (create-muuntaja muuntaja-options))
+   (create-muuntaja m/default-options))
   ([muuntaja-or-options]
    (if muuntaja-or-options
      (if (instance? Muuntaja muuntaja-or-options)
@@ -183,7 +181,7 @@
 ;;
 
 (def api-middleware-defaults
-  {:formats muuntaja-options
+  {:formats m/default-options
    :exceptions {:handlers {::ex/request-validation ex/request-validation-handler
                            ::ex/request-parsing ex/request-parsing-handler
                            ::ex/response-validation ex/response-validation-handler

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -766,7 +766,6 @@
 
       ?content-type ?body
       "application/json" "{\"foo\":\"bar\"}"
-      "application/x-yaml" "{foo: bar}\n"
       "application/edn" "{:foo \"bar\"}"
       "application/transit+json" "[\"^ \",\"~:foo\",\"bar\"]")))
 
@@ -1556,7 +1555,7 @@
                   response => http/ok?
                   (m/decode m format (:body response)) => valid-data)))))))
 
-    (facts "application/json & application/x-yaml - coerce request, validate response"
+    (facts "application/json - coerce request, validate response"
       (let [valid-data {:int 1, :keyword "kikka"}
             valid-response-data {:int 1, :keyword :kikka}
             invalid-data {:int "1", :keyword "kikka"}
@@ -1567,7 +1566,7 @@
                     :return Schema
                     (ok *response*)))]
 
-        (doseq [format ["application/json" "application/x-yaml"]]
+        (doseq [format ["application/json"]]
           (fact {:midje/description format}
 
             (fact "fails with invalid body"
@@ -1585,11 +1584,7 @@
               (binding [*response* valid-response-data]
                 (let [response (app (ring-request m format valid-data))]
                   response => http/ok?
-                  (m/decode m format (:body response)) => valid-data)))))))
-
-    (facts "msgpack"
-      ;; TODO: implement
-      )))
+                  (m/decode m format (:body response)) => valid-data)))))))))
 
 (fact "static contexts just work"
   (let [app (context "/:a" [a]

--- a/test/compojure/api/sweet_test.clj
+++ b/test/compojure/api/sweet_test.clj
@@ -117,16 +117,12 @@
                  :basePath "/"
                  :consumes (just
                              ["application/json"
-                              "application/x-yaml"
-                              "application/msgpack"
                               "application/edn"
                               "application/transit+json"
                               "application/transit+msgpack"]
                              :in-any-order),
                  :produces (just
                              ["application/json"
-                              "application/x-yaml"
-                              "application/msgpack"
                               "application/edn"
                               "application/transit+json"
                               "application/transit+msgpack"]


### PR DESCRIPTION
Dropping the second class formats YAML & Msgpack. Both libs are not fully tested, cause reflection warning and don't seem to be actively maintained. Guide how to add them back. If this is approved, https://github.com/metosin/compojure-api/wiki/Migration-Guide-to-2.0.0 should be updated too.