### PR TITLE
Drop cheshire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## UNRELEASED
+
+* Use Muuntaja for all JSON transformations, drop direct dependency to Cheshire.
+
+* dropped dependencies:
+
+```clj
+[cheshire "5.7.1"]
+```
+
 ## 2.0.0-alpha7 (31.7.2017)
 
 * drop direct support for `application/yaml` & `application/msgpack`. If you want to add them back, you need to manually add the dependencies below and configure Muuntaja to handle those:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## UNRELEASED
 
 * Use Muuntaja for all JSON transformations, drop direct dependency to Cheshire.
+* Muuntaja `api` instance (if defined) is injected into `::request/muuntaja` for endpoints to use.
+  * **BREAKING**: `path-for` and `path-for*` now use this to encode path-parameters.
 
 * dropped dependencies:
 

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,6 @@
             :distribution :repo
             :comments "same as Clojure"}
   :dependencies [[potemkin "0.4.3"]
-                 [cheshire "5.7.1" :exclusions [com.fasterxml.jackson.core/jackson-core]]
                  [prismatic/schema "1.1.6"]
                  [prismatic/plumbing "0.5.4"]
                  [org.tobereplaced/lettercase "1.0.0"]

--- a/src/compojure/api/api.clj
+++ b/src/compojure/api/api.clj
@@ -1,7 +1,7 @@
 (ns compojure.api.api
   (:require [compojure.api.core :as c]
             [compojure.api.swagger :as swagger]
-            [compojure.api.middleware :as middleware]
+            [compojure.api.middleware :as mw]
             [compojure.api.request :as request]
             [compojure.api.routes :as routes]
             [compojure.api.common :as common]
@@ -12,7 +12,7 @@
 
 (def api-defaults
   (merge
-    middleware/api-middleware-defaults
+    mw/api-middleware-defaults
     {:api {:invalid-routes-fn routes/log-invalid-child-routes
            :disable-api-middleware? false}
      :swagger {:ui nil, :spec nil}}))
@@ -66,12 +66,12 @@
         lookup (routes/route-lookup-table routes)
         swagger-data (get-in options [:swagger :data])
         enable-api-middleware? (not (get-in options [:api :disable-api-middleware?]))
-        api-middleware-options (middleware/api-middleware-options (dissoc options :api :swagger))
+        api-middleware-options (mw/api-middleware-options (dissoc options :api :swagger))
         api-handler (-> handler
                         (cond-> swagger-data (rsm/wrap-swagger-data swagger-data))
-                        (cond-> enable-api-middleware? (middleware/api-middleware
+                        (cond-> enable-api-middleware? (mw/api-middleware
                                                          api-middleware-options))
-                        (middleware/wrap-inject-data
+                        (mw/wrap-inject-data
                           {::request/paths paths
                            ::request/lookup lookup}))]
     (assoc partial-api-route :handler api-handler)))

--- a/src/compojure/api/impl/json.clj
+++ b/src/compojure/api/impl/json.clj
@@ -4,9 +4,3 @@
 
 (def instance
   (m/create))
-
-(defn generate-string [x]
-  (slurp (m/encode instance "application/json" x)))
-
-(defn parse-string [x]
-  (m/decode instance "application/json" x))

--- a/src/compojure/api/impl/json.clj
+++ b/src/compojure/api/impl/json.clj
@@ -1,0 +1,12 @@
+(ns ^:no-doc compojure.api.impl.json
+  "Internal JSON formatting"
+  (:require [muuntaja.core :as m]))
+
+(def instance
+  (m/create))
+
+(defn generate-string [x]
+  (slurp (m/encode instance "application/json" x)))
+
+(defn parse-string [x]
+  (m/decode instance "application/json" x))

--- a/src/compojure/api/impl/json.clj
+++ b/src/compojure/api/impl/json.clj
@@ -2,5 +2,5 @@
   "Internal JSON formatting"
   (:require [muuntaja.core :as m]))
 
-(def instance
+(def muuntaja
   (m/create))

--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -263,6 +263,7 @@
          (cond-> muuntaja (wrap-swagger-data (select-keys muuntaja [:consumes :produces])))
          (wrap-inject-data
            (cond-> {::request/coercion coercion}
+                   muuntaja (assoc ::request/muuntaja muuntaja)
                    ring-swagger (assoc ::request/ring-swagger ring-swagger)))
          (cond-> muuntaja (muuntaja.middleware/wrap-params))
          ;; all but request-parsing exceptions (to make :body-params visible)

--- a/src/compojure/api/request.clj
+++ b/src/compojure/api/request.clj
@@ -19,3 +19,7 @@
 (def lookup
   "Reverse routing tree"
   ::lookup)
+
+(def muuntaja
+  "Muuntaja instance"
+  ::muuntaja)

--- a/src/compojure/api/routes.clj
+++ b/src/compojure/api/routes.clj
@@ -223,7 +223,7 @@
 (defn path-for*
   "Extracts the lookup-table from request and finds a route by name."
   [route-name request & [params]]
-  (let [m json/instance
+  (let [m (or (::request/muuntaja request) json/instance)
         [path details] (some-> request
                                ::request/lookup
                                route-name

--- a/src/compojure/api/routes.clj
+++ b/src/compojure/api/routes.clj
@@ -223,7 +223,7 @@
 (defn path-for*
   "Extracts the lookup-table from request and finds a route by name."
   [route-name request & [params]]
-  (let [m (or (::request/muuntaja request) json/instance)
+  (let [m (or (::request/muuntaja request) json/muuntaja)
         [path details] (some-> request
                                ::request/lookup
                                route-name

--- a/src/compojure/api/validator.clj
+++ b/src/compojure/api/validator.clj
@@ -2,6 +2,7 @@
   (:require [compojure.api.swagger :as swagger]
             [compojure.api.impl.json :as json]
             [ring.swagger.validator :as rsv]
+            [muuntaja.core :as m]
             [compojure.api.middleware :as mw]))
 
 (defn validate
@@ -14,7 +15,7 @@
     (let [{status :status :as response} (api {:request-method :get
                                               :uri uri
                                               ::mw/rethrow-exceptions? true})
-          body (-> response :body slurp json/parse-string)]
+          body (->> response :body slurp (m/decode json/instance "application/json"))]
 
       (when-not (= status 200)
         (throw (ex-info (str "Coudn't read swagger spec from " uri)

--- a/src/compojure/api/validator.clj
+++ b/src/compojure/api/validator.clj
@@ -1,6 +1,6 @@
 (ns compojure.api.validator
   (:require [compojure.api.swagger :as swagger]
-            [cheshire.core :as cheshire]
+            [compojure.api.impl.json :as json]
             [ring.swagger.validator :as rsv]
             [compojure.api.middleware :as mw]))
 
@@ -14,7 +14,7 @@
     (let [{status :status :as response} (api {:request-method :get
                                               :uri uri
                                               ::mw/rethrow-exceptions? true})
-          body (-> response :body slurp (cheshire/parse-string true))]
+          body (-> response :body slurp json/parse-string)]
 
       (when-not (= status 200)
         (throw (ex-info (str "Coudn't read swagger spec from " uri)

--- a/src/compojure/api/validator.clj
+++ b/src/compojure/api/validator.clj
@@ -15,7 +15,7 @@
     (let [{status :status :as response} (api {:request-method :get
                                               :uri uri
                                               ::mw/rethrow-exceptions? true})
-          body (->> response :body slurp (m/decode json/instance "application/json"))]
+          body (->> response :body (m/decode json/instance "application/json"))]
 
       (when-not (= status 200)
         (throw (ex-info (str "Coudn't read swagger spec from " uri)

--- a/src/compojure/api/validator.clj
+++ b/src/compojure/api/validator.clj
@@ -15,7 +15,7 @@
     (let [{status :status :as response} (api {:request-method :get
                                               :uri uri
                                               ::mw/rethrow-exceptions? true})
-          body (->> response :body (m/decode json/instance "application/json"))]
+          body (->> response :body (m/decode json/muuntaja "application/json"))]
 
       (when-not (= status 200)
         (throw (ex-info (str "Coudn't read swagger spec from " uri)

--- a/test/compojure/api/coercion/schema_coercion_test.clj
+++ b/test/compojure/api/coercion/schema_coercion_test.clj
@@ -3,6 +3,7 @@
             [schema.core :as s]
             [compojure.api.sweet :refer :all]
             [compojure.api.test-utils :refer :all]
+            [compojure.api.impl.json :as json]
             [compojure.api.request :as request]
             [compojure.api.coercion :as coercion]
             [compojure.api.validator :as validator]
@@ -185,20 +186,20 @@
                  :value {:x "1", :y "kaks"}}))
 
     (fact "body"
-      (let [[status body] (post* app "/body" (json {:x 1, :y 2, #_#_:z 3}))]
+      (let [[status body] (post* app "/body" (json-string {:x 1, :y 2, #_#_:z 3}))]
         status => 200
         body => {:total 3}))
 
     (fact "body-map"
-      (let [[status body] (post* app "/body-map" (json {:x 1, :y 2}))]
+      (let [[status body] (post* app "/body-map" (json-string {:x 1, :y 2}))]
         status => 200
         body => {:total 3})
-      (let [[status body] (post* app "/body-map" (json {:x 1}))]
+      (let [[status body] (post* app "/body-map" (json-string {:x 1}))]
         status => 200
         body => {:total 1}))
 
     (fact "body-string"
-      (let [[status body] (post* app "/body-string" (json "kikka"))]
+      (let [[status body] (post* app "/body-string" (json-string "kikka"))]
         status => 200
         body => {:body "kikka"}))
 
@@ -212,13 +213,13 @@
                            :in ["request" "query-params"]})))
 
     (fact "body-params"
-      (let [[status body] (post* app "/body-params" (json {:x 1, :y 2}))]
+      (let [[status body] (post* app "/body-params" (json-string {:x 1, :y 2}))]
         status => 200
         body => {:total 3})
-      (let [[status body] (post* app "/body-params" (json {:x 1}))]
+      (let [[status body] (post* app "/body-params" (json-string {:x 1}))]
         status => 200
         body => {:total 1})
-      (let [[status body] (post* app "/body-params" (json {:x "1"}))]
+      (let [[status body] (post* app "/body-params" (json-string {:x "1"}))]
         status => 400
         body => (contains {:coercion "schema"
                            :in ["request" "body-params"]})))
@@ -243,13 +244,13 @@
                              :in ["response" "body"]})))
 
       (fact "parameters as data-specs"
-        (let [[status body] (post* app "/resource" (json {:x 1, :y 2}))]
+        (let [[status body] (post* app "/resource" (json-string {:x 1, :y 2}))]
           status => 200
           body => {:total 3})
-        (let [[status body] (post* app "/resource" (json {:x 1}))]
+        (let [[status body] (post* app "/resource" (json-string {:x 1}))]
           status => 200
           body => {:total 1})
-        (let [[status body] (post* app "/resource" (json {:x -1, :y -2}))]
+        (let [[status body] (post* app "/resource" (json-string {:x -1, :y -2}))]
           status => 500
           body => (contains {:coercion "schema"
                              :in ["response" "body"]}))))

--- a/test/compojure/api/coercion/schema_coercion_test.clj
+++ b/test/compojure/api/coercion/schema_coercion_test.clj
@@ -3,7 +3,6 @@
             [schema.core :as s]
             [compojure.api.sweet :refer :all]
             [compojure.api.test-utils :refer :all]
-            [compojure.api.impl.json :as json]
             [compojure.api.request :as request]
             [compojure.api.coercion :as coercion]
             [compojure.api.validator :as validator]

--- a/test/compojure/api/coercion_test.clj
+++ b/test/compojure/api/coercion_test.clj
@@ -90,7 +90,7 @@
         (fact "by default, applies body coercion (to set)"
           (let [app (api
                       beer-route)]
-            (let [[status body] (post* app "/beer" (json {:beers ["ipa" "apa" "ipa"]}))]
+            (let [[status body] (post* app "/beer" (json-string {:beers ["ipa" "apa" "ipa"]}))]
               status => 200
               body => {:beers ["ipa" "apa"]})))
 
@@ -99,13 +99,13 @@
                 app (api
                       {:coercion no-body-coercion}
                       beer-route)]
-            (let [[status body] (post* app "/beer" (json {:beers ["ipa" "apa" "ipa"]}))]
+            (let [[status body] (post* app "/beer" (json-string {:beers ["ipa" "apa" "ipa"]}))]
               status => 200
               body => {:beers ["ipa" "apa" "ipa"]}))
           (let [app (api
                       {:coercion nil}
                       beer-route)]
-            (let [[status body] (post* app "/beer" (json {:beers ["ipa" "apa" "ipa"]}))]
+            (let [[status body] (post* app "/beer" (json-string {:beers ["ipa" "apa" "ipa"]}))]
               status => 200
               body => {:beers ["ipa" "apa" "ipa"]})))
 
@@ -114,7 +114,7 @@
                 app (api
                       {:coercion nop-body-coercion}
                       beer-route)]
-            (post* app "/beer" (json {:beers ["ipa" "apa" "ipa"]})) => (fails-with 400)))))
+            (post* app "/beer" (json-string {:beers ["ipa" "apa" "ipa"]})) => (fails-with 400)))))
 
     (fact "query coercion"
       (let [query-route (GET "/query" []

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -16,8 +16,7 @@
             [compojure.api.routes :as routes]
             [clojure.java.io :as io]
             [muuntaja.core :as m]
-            [compojure.api.core :as c]
-            [compojure.api.middleware :as middleware])
+            [compojure.api.core :as c])
   (:import (java.sql SQLException SQLWarning)
            (java.io File)))
 
@@ -1523,7 +1522,7 @@
 (def ^:dynamic *response* nil)
 
 (facts "format-based body & response coercion"
-  (let [m (middleware/create-muuntaja)]
+  (let [m (mw/create-muuntaja)]
 
     (facts "application/transit & application/edn validate request & response (no coercion)"
       (let [valid-data {:items {"kikka" :kukka}}

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -13,6 +13,7 @@
             [compojure.api.middleware :as mw]
             [ring.swagger.middleware :as rsm]
             [compojure.api.validator :as validator]
+            [compojure.api.request :as request]
             [compojure.api.routes :as routes]
             [clojure.java.io :as io]
             [muuntaja.core :as m]
@@ -1475,6 +1476,15 @@
       => (contains
            {:produces (just ["application/vnd.vendor.v1+json" "application/json"] :in-any-order)
             :consumes (just ["application/vnd.vendor.v1+json" "application/json"] :in-any-order)}))))
+
+(facts "muuntaja is bound in request"
+  (let [app (api
+              (GET "/ping" {:keys [::request/muuntaja]}
+                (ok {:pong (slurp (m/encode muuntaja "application/json" {:is "json"}))})))]
+
+    (let [[status body] (get* app "/ping")]
+      status => 200
+      body => {:pong "{\"is\":\"json\"}"})))
 
 (facts ":body doesn't keywordize keys"
   (let [m (m/create)

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -14,11 +14,7 @@
             [ring.swagger.middleware :as rsm]
             [compojure.api.validator :as validator]
             [compojure.api.routes :as routes]
-            [muuntaja.core :as muuntaja]
-            [muuntaja.core :as formats]
-            [cheshire.core :as json]
             [clojure.java.io :as io]
-            [muuntaja.core :as muuntaja]
             [muuntaja.core :as m]
             [compojure.api.core :as c]
             [compojure.api.middleware :as middleware])
@@ -242,22 +238,22 @@
         body => pertti))
 
     (fact "POST with smart destructuring"
-      (let [[status body] (post* app "/models/user" (json pertti))]
+      (let [[status body] (post* app "/models/user" (json-string pertti))]
         status => 200
         body => pertti))
 
     (fact "POST with smart destructuring - lists"
-      (let [[status body] (post* app "/models/user_list" (json [pertti]))]
+      (let [[status body] (post* app "/models/user_list" (json-string [pertti]))]
         status => 200
         body => [pertti]))
 
     (fact "POST with smart destructuring - sets"
-      (let [[status body] (post* app "/models/user_set" (json #{pertti}))]
+      (let [[status body] (post* app "/models/user_set" (json-string #{pertti}))]
         status => 200
         body => [pertti]))
 
     (fact "POST with compojure destructuring"
-      (let [[status body] (post* app "/models/user_legacy" (json pertti))]
+      (let [[status body] (post* app "/models/user_legacy" (json-string pertti))]
         status => 200
         body => pertti))
 
@@ -409,12 +405,12 @@
         body => {:total 2}))
 
     (fact "body-parameters"
-      (let [[status body] (post* app "/smart/minus" (json {:x 2 :y 3}))]
+      (let [[status body] (post* app "/smart/minus" (json-string {:x 2 :y 3}))]
         status => 200
         body => {:total -1}))
 
     (fact "default parameters"
-      (let [[status body] (post* app "/smart/minus" (json {:x 2}))]
+      (let [[status body] (post* app "/smart/minus" (json-string {:x 2}))]
         status => 200
         body => {:total 1}))))
 
@@ -451,7 +447,7 @@
         body => "\"kikka\""))
 
     (fact "primitive arrays work"
-      (let [[status body] (raw-post* app "/primitives/arrays" (json/generate-string [1 2 3]))]
+      (let [[status body] (raw-post* app "/primitives/arrays" (json-string [1 2 3]))]
         status => 200
         body => "[1,2,3]"))
 
@@ -520,8 +516,8 @@
 
 (fact "swagger-docs"
   (let [app (api
-              {:formats (muuntaja/select-formats
-                          muuntaja/default-options
+              {:formats (m/select-formats
+                          m/default-options
                           ["application/json" "application/edn"])}
               (swagger-routes)
               (GET "/user" []
@@ -797,13 +793,13 @@
 
     (fact "direct route with nested named schema works when called"
       (let [pizza {:toppings [{:name "cheese"}]}
-            [status body] (post* app "/pizza" (json pizza))]
+            [status body] (post* app "/pizza" (json-string pizza))]
         status => 200
         body => pizza))
 
     (fact "defroute*'d route with nested named schema works when called"
       (let [burger {:ingredients [{:name "beef"}, {:name "egg"}]}
-            [status body] (post* app "/burger" (json burger))]
+            [status body] (post* app "/burger" (json-string burger))]
         status => 200
         body => burger))
 
@@ -1458,9 +1454,9 @@
                        :encoder [muuntaja.format.json/make-json-encoder]}
         app (api
               {:swagger {:spec "/swagger.json"}
-               :formats (-> muuntaja/default-options
+               :formats (-> m/default-options
                             (update :formats assoc custom-type custom-format)
-                            (muuntaja/select-formats ["application/json" custom-type]))}
+                            (m/select-formats ["application/json" custom-type]))}
               (POST "/echo" []
                 :body [data {:kikka s/Str}]
                 (ok data)))]
@@ -1472,7 +1468,7 @@
                            :headers {"content-type" "application/vnd.vendor.v1+json"
                                      "accept" "application/vnd.vendor.v1+json"}})]
 
-        (-> response :body slurp) => (json {:kikka "kukka"})
+        (-> response :body slurp) => (json-string {:kikka "kukka"})
         (-> response :headers) => (contains {"Content-Type" "application/vnd.vendor.v1+json; charset=utf-8"})))
 
     (fact "spec is correct"
@@ -1482,7 +1478,7 @@
             :consumes (just ["application/vnd.vendor.v1+json" "application/json"] :in-any-order)}))))
 
 (facts ":body doesn't keywordize keys"
-  (let [m (muuntaja/create)
+  (let [m (m/create)
         data {:items {"kikka" 42}}
         body* (atom nil)
         app (api
@@ -1499,7 +1495,7 @@
     (facts ":body-params keywordizes params"
       (app {:uri "/echo"
             :request-method :post
-            :body (muuntaja/encode m "application/transit+json" data)
+            :body (m/encode m "application/transit+json" data)
             :headers {"content-type" "application/transit+json"
                       "accept" "application/transit+json"}}) => http/ok?
       @body* => {:items {:kikka 42}})
@@ -1507,7 +1503,7 @@
     (facts ":body does not keywordizes params"
       (app {:uri "/echo2"
             :request-method :post
-            :body (muuntaja/encode m "application/transit+json" data)
+            :body (m/encode m "application/transit+json" data)
             :headers {"content-type" "application/transit+json"
                       "accept" "application/transit+json"}}) => http/ok?
       @body* => {:items {"kikka" 42}})
@@ -1643,14 +1639,14 @@
                   (ok {:ok true})))
           response (app {:uri "/a"
                          :request-method :get})]
-      (-> response :body slurp) => (json {:ok true})
+      (-> response :body slurp) => (json-string {:ok true})
       (fact "middleware is called"
         @called? => truthy)
 
       (reset! called? false)
       (let [response (app {:uri "/b"
                            :request-method :get})]
-        (-> response :body slurp) => (json {:ok true})
+        (-> response :body slurp) => (json-string {:ok true})
         @called? => falsey)))
 
   (fact "middleware with args"
@@ -1668,14 +1664,14 @@
                   (ok {:ok true})))
           response (app {:uri "/a"
                          :request-method :get})]
-      (-> response :body slurp) => (json {:ok true})
+      (-> response :body slurp) => (json-string {:ok true})
       (fact "middleware is called"
         @mw-value => :foo-bar)
 
       (reset! mw-value nil)
       (let [response (app {:uri "/b"
                            :request-method :get})]
-        (-> response :body slurp) => (json {:ok true})
+        (-> response :body slurp) => (json-string {:ok true})
         @mw-value => nil))))
 
 (facts "ring-handler"
@@ -1690,7 +1686,7 @@
 
 (fact ":body-params are set to :params"
   (let [app (api (POST "/echo" [x] (ok {:x x})))
-        [status body] (post* app "/echo" (json {:x 1}))]
+        [status body] (post* app "/echo" (json-string {:x 1}))]
     status => 200
     body => {:x 1}))
 
@@ -1703,6 +1699,6 @@
                    (internal-server-error (:body-params request)))}}}
               (POST "/error" []
                 (throw (RuntimeException. "error"))))
-        [status body] (post* app "/error" (json {:kikka 6}))]
+        [status body] (post* app "/error" (json-string {:kikka 6}))]
     status => 500
     body => {:kikka 6}))

--- a/test/compojure/api/perf_test.clj
+++ b/test/compojure/api/perf_test.clj
@@ -1,6 +1,5 @@
 (ns compojure.api.perf-test
   (:require [compojure.api.sweet :refer :all]
-            [compojure.api.impl.json :as json]
             [compojure.api.test-utils :as h]
             [criterium.core :as cc]
             [ring.util.http-response :refer :all]
@@ -77,7 +76,7 @@
         call #(post* app "/plus" data)]
 
     (title "JSON POST with 2-way coercion")
-    (assert (= {:result 30} (json/parse-string (call))))
+    (assert (= {:result 30} (h/parse (call))))
     (cc/bench (call)))
 
   ;; 85µs
@@ -96,7 +95,7 @@
         call #(post* app "/a/b/c/plus" data)]
 
     (title "JSON POST with 2-way coercion + contexts")
-    (assert (= {:result 30} (json/parse-string (call))))
+    (assert (= {:result 30} (h/parse (call))))
     (cc/bench (call)))
 
   ;; 266µs
@@ -122,7 +121,7 @@
         call #(post* app "/echo" data)]
 
     (title "JSON POST with nested data")
-    (s/validate Order (json/parse-string (call)))
+    (s/validate Order (h/parse (call)))
     (cc/bench (call))))
 
 (defn resource-bench []
@@ -142,7 +141,7 @@
           call #(post* app "/plus" data)]
 
       (title "JSON POST to pre-defined resource with 2-way coercion")
-      (assert (= {:result 30} (json/parse-string (call))))
+      (assert (= {:result 30} (h/parse (call))))
       (cc/bench (call)))
 
     ;; 68µs
@@ -154,7 +153,7 @@
           call #(post* app "/plus" data)]
 
       (title "JSON POST to inlined resource with 2-way coercion")
-      (assert (= {:result 30} (json/parse-string (call))))
+      (assert (= {:result 30} (h/parse (call))))
       (cc/bench (call)))
 
     ;; 26µs
@@ -208,7 +207,7 @@
                   "dev-resources/json/json1k.json"
                   "dev-resources/json/json10k.json"
                   "dev-resources/json/json100k.json"]
-            :let [data (json/parse-string (slurp file))
+            :let [data (h/parse (slurp file))
                   request (json-request data)
                   request! (request-stream request)]]
 

--- a/test/compojure/api/perf_test.clj
+++ b/test/compojure/api/perf_test.clj
@@ -1,12 +1,11 @@
 (ns compojure.api.perf-test
   (:require [compojure.api.sweet :refer :all]
+            [compojure.api.impl.json :as json]
             [compojure.api.test-utils :as h]
             [criterium.core :as cc]
             [ring.util.http-response :refer :all]
             [schema.core :as s]
-            [clojure.java.io :as io]
-            [cheshire.core :as json]
-            [cheshire.core :as cheshire])
+            [clojure.java.io :as io])
   (:import (java.io ByteArrayInputStream)))
 
 ;;
@@ -41,8 +40,6 @@
     :body
     slurp))
 
-(defn parse [s] (json/parse-string s true))
-
 (s/defschema Order {:id s/Str
                     :name s/Str
                     (s/optional-key :description) s/Str
@@ -76,11 +73,11 @@
                 :return {:result s/Int}
                 :body-params [x :- s/Int, y :- s/Int]
                 (ok {:result (+ x y)})))
-        data (h/json {:x 10, :y 20})
+        data (h/json-string {:x 10, :y 20})
         call #(post* app "/plus" data)]
 
     (title "JSON POST with 2-way coercion")
-    (assert (= {:result 30} (parse (call))))
+    (assert (= {:result 30} (json/parse-string (call))))
     (cc/bench (call)))
 
   ;; 85µs
@@ -95,11 +92,11 @@
                       :return {:result s/Int}
                       :body-params [x :- s/Int, y :- s/Int]
                       (ok {:result (+ x y)}))))))
-        data (h/json {:x 10, :y 20})
+        data (h/json-string {:x 10, :y 20})
         call #(post* app "/a/b/c/plus" data)]
 
     (title "JSON POST with 2-way coercion + contexts")
-    (assert (= {:result 30} (parse (call))))
+    (assert (= {:result 30} (json/parse-string (call))))
     (cc/bench (call)))
 
   ;; 266µs
@@ -111,7 +108,7 @@
                 :return Order
                 :body [order Order]
                 (ok order)))
-        data (h/json {:id "123"
+        data (h/json-string {:id "123"
                       :name "Tommi's order"
                       :description "Totally great order"
                       :address {:street "Randomstreet 123"
@@ -125,7 +122,7 @@
         call #(post* app "/echo" data)]
 
     (title "JSON POST with nested data")
-    (s/validate Order (parse (call)))
+    (s/validate Order (json/parse-string (call)))
     (cc/bench (call))))
 
 (defn resource-bench []
@@ -141,11 +138,11 @@
           app (api
                 (context "/plus" []
                   my-resource))
-          data (h/json {:x 10, :y 20})
+          data (h/json-string {:x 10, :y 20})
           call #(post* app "/plus" data)]
 
       (title "JSON POST to pre-defined resource with 2-way coercion")
-      (assert (= {:result 30} (parse (call))))
+      (assert (= {:result 30} (json/parse-string (call))))
       (cc/bench (call)))
 
     ;; 68µs
@@ -153,11 +150,11 @@
     (let [app (api
                 (context "/plus" []
                   (resource resource-map)))
-          data (h/json {:x 10, :y 20})
+          data (h/json-string {:x 10, :y 20})
           call #(post* app "/plus" data)]
 
       (title "JSON POST to inlined resource with 2-way coercion")
-      (assert (= {:result 30} (parse (call))))
+      (assert (= {:result 30} (json/parse-string (call))))
       (cc/bench (call)))
 
     ;; 26µs
@@ -197,7 +194,7 @@
                         :request-method :post
                         :headers {"content-type" "application/json"
                                   "accept" "application/json"}
-                        :body (cheshire/generate-string data)})
+                        :body (h/json-string data)})
         request-stream (fn [request]
                          (let [b (.getBytes ^String (:body request))]
                            (fn []
@@ -211,7 +208,7 @@
                   "dev-resources/json/json1k.json"
                   "dev-resources/json/json10k.json"
                   "dev-resources/json/json100k.json"]
-            :let [data (cheshire/parse-string (slurp file))
+            :let [data (json/parse-string (slurp file))
                   request (json-request data)
                   request! (request-stream request)]]
 

--- a/test/compojure/api/routes_test.clj
+++ b/test/compojure/api/routes_test.clj
@@ -3,7 +3,6 @@
             [compojure.api.sweet :refer :all]
             [compojure.api.core :refer [route-middleware]]
             [compojure.api.routes :as routes]
-            [compojure.api.impl.json :as json]
             [ring.util.http-response :refer :all]
             [ring.util.http-predicates :refer :all]
             [compojure.api.test-utils :refer :all]
@@ -15,15 +14,15 @@
 (facts "path-string"
 
   (fact "missing path parameter"
-    (#'routes/path-string json/instance "/api/:kikka" {})
+    (#'routes/path-string muuntaja "/api/:kikka" {})
     => (throws IllegalArgumentException))
 
   (fact "missing serialization"
-    (#'routes/path-string json/instance "/api/:kikka" {:kikka (SecureRandom.)})
+    (#'routes/path-string muuntaja "/api/:kikka" {:kikka (SecureRandom.)})
     => (throws ExceptionInfo #"Malformed application/json"))
 
   (fact "happy path"
-    (#'routes/path-string json/instance "/a/:b/:c/d/:e/f" {:b (LocalDate/parse "2015-05-22")
+    (#'routes/path-string muuntaja "/a/:b/:c/d/:e/f" {:b (LocalDate/parse "2015-05-22")
                                                            :c 12345
                                                            :e :kikka})
     => "/a/2015-05-22/12345/d/kikka/f"))

--- a/test/compojure/api/routes_test.clj
+++ b/test/compojure/api/routes_test.clj
@@ -3,28 +3,29 @@
             [compojure.api.sweet :refer :all]
             [compojure.api.core :refer [route-middleware]]
             [compojure.api.routes :as routes]
+            [compojure.api.impl.json :as json]
             [ring.util.http-response :refer :all]
             [ring.util.http-predicates :refer :all]
             [compojure.api.test-utils :refer :all]
             [schema.core :as s])
   (:import (java.security SecureRandom)
            (org.joda.time LocalDate)
-           (com.fasterxml.jackson.core JsonGenerationException)))
+           (clojure.lang ExceptionInfo)))
 
 (facts "path-string"
 
   (fact "missing path parameter"
-    (#'routes/path-string "/api/:kikka" {})
+    (#'routes/path-string json/instance "/api/:kikka" {})
     => (throws IllegalArgumentException))
 
   (fact "missing serialization"
-    (#'routes/path-string "/api/:kikka" {:kikka (SecureRandom.)})
-    => (throws JsonGenerationException))
+    (#'routes/path-string json/instance "/api/:kikka" {:kikka (SecureRandom.)})
+    => (throws ExceptionInfo #"Malformed application/json"))
 
   (fact "happy path"
-    (#'routes/path-string "/a/:b/:c/d/:e/f" {:b (LocalDate/parse "2015-05-22")
-                                             :c 12345
-                                             :e :kikka})
+    (#'routes/path-string json/instance "/a/:b/:c/d/:e/f" {:b (LocalDate/parse "2015-05-22")
+                                                           :c 12345
+                                                           :e :kikka})
     => "/a/2015-05-22/12345/d/kikka/f"))
 
 (fact "string-path-parameters"

--- a/test/compojure/api/test_utils.clj
+++ b/test/compojure/api/test_utils.clj
@@ -1,10 +1,11 @@
 (ns compojure.api.test-utils
-  (:require [cheshire.core :as cheshire]
-            [clojure.string :as str]
+  (:require [clojure.string :as str]
             [peridot.core :as p]
             [clojure.java.io :as io]
+            [muuntaja.core :as m]
             [compojure.api.routes :as routes]
-            [muuntaja.core :as muuntaja])
+            [compojure.api.impl.json :as json]
+            [compojure.api.middleware :as middleware])
   (:import (java.io InputStream)))
 
 (defn read-body [body]
@@ -15,7 +16,7 @@
 (defn parse-body [body]
   (let [body (read-body body)
         body (if (instance? String body)
-               (cheshire/parse-string body true)
+               (json/parse-string body)
                body)]
     body))
 
@@ -34,9 +35,8 @@
 ;; common
 ;;
 
-(defn json [x] (cheshire/generate-string x))
-
-(defn json-stream [x] (io/input-stream (.getBytes (json x))))
+(def json-string json/generate-string)
+(defn json-stream [x] (io/input-stream (.getBytes (json/generate-string x))))
 
 (defn follow-redirect [state]
   (if (some-> state :response :headers (get "Location"))
@@ -118,7 +118,7 @@
 (defn ring-request [m format data]
   {:uri "/echo"
    :request-method :post
-   :body (muuntaja/encode m format data)
+   :body (m/encode m format data)
    :headers {"content-type" format
              "accept" format}})
 ;;

--- a/test/compojure/api/test_utils.clj
+++ b/test/compojure/api/test_utils.clj
@@ -4,9 +4,10 @@
             [clojure.java.io :as io]
             [muuntaja.core :as m]
             [compojure.api.routes :as routes]
-            [compojure.api.impl.json :as json]
             [compojure.api.middleware :as mw])
   (:import (java.io InputStream)))
+
+(def muuntaja (m/create))
 
 (defn read-body [body]
   (if (instance? InputStream body)
@@ -16,7 +17,7 @@
 (defn parse-body [body]
   (let [body (read-body body)
         body (if (instance? String body)
-               (m/decode json/instance "application/json" body)
+               (m/decode muuntaja "application/json" body)
                body)]
     body))
 
@@ -27,21 +28,13 @@
   (let [schema-name (keyword (extract-schema-name ref))]
     (get-in spec [:definitions schema-name])))
 
-;;
-;; integration tests
-;;
-
-;;
-;; common
-;;
-
 (defn json-stream [x]
-  (m/encode json/instance "application/json" x))
+  (m/encode muuntaja "application/json" x))
 
 (def json-string (comp slurp json-stream))
 
 (defn parse [x]
-  (m/decode json/instance "application/json" x))
+  (m/decode muuntaja "application/json" x))
 
 (defn follow-redirect [state]
   (if (some-> state :response :headers (get "Location"))
@@ -126,6 +119,7 @@
    :body (m/encode m format data)
    :headers {"content-type" format
              "accept" format}})
+
 ;;
 ;; get-spec
 ;;

--- a/test/compojure/api/test_utils.clj
+++ b/test/compojure/api/test_utils.clj
@@ -5,7 +5,7 @@
             [muuntaja.core :as m]
             [compojure.api.routes :as routes]
             [compojure.api.impl.json :as json]
-            [compojure.api.middleware :as middleware])
+            [compojure.api.middleware :as mw])
   (:import (java.io InputStream)))
 
 (defn read-body [body]

--- a/test/compojure/api/test_utils.clj
+++ b/test/compojure/api/test_utils.clj
@@ -16,7 +16,7 @@
 (defn parse-body [body]
   (let [body (read-body body)
         body (if (instance? String body)
-               (json/parse-string body)
+               (m/decode json/instance "application/json" body)
                body)]
     body))
 
@@ -35,8 +35,13 @@
 ;; common
 ;;
 
-(def json-string json/generate-string)
-(defn json-stream [x] (io/input-stream (.getBytes (json/generate-string x))))
+(defn json-stream [x]
+  (m/encode json/instance "application/json" x))
+
+(def json-string (comp slurp json-stream))
+
+(defn parse [x]
+  (m/decode json/instance "application/json" x))
 
 (defn follow-redirect [state]
   (if (some-> state :response :headers (get "Location"))

--- a/test19/compojure/api/coercion/spec_coercion_test.clj
+++ b/test19/compojure/api/coercion/spec_coercion_test.clj
@@ -197,20 +197,20 @@
                  :value {:x "1", :y "kaks"}}))
 
     (fact "body"
-      (let [[status body] (post* app "/body" (json {:x 1, :y 2, :z 3}))]
+      (let [[status body] (post* app "/body" (json-string {:x 1, :y 2, :z 3}))]
         status => 200
         body => {:total 3}))
 
     (fact "body-map"
-      (let [[status body] (post* app "/body-map" (json {:x 1, :y 2}))]
+      (let [[status body] (post* app "/body-map" (json-string {:x 1, :y 2}))]
         status => 200
         body => {:total 3})
-      (let [[status body] (post* app "/body-map" (json {:x 1}))]
+      (let [[status body] (post* app "/body-map" (json-string {:x 1}))]
         status => 200
         body => {:total 1}))
 
     (fact "body-string"
-      (let [[status body] (post* app "/body-string" (json "kikka"))]
+      (let [[status body] (post* app "/body-string" (json-string "kikka"))]
         status => 200
         body => {:body "kikka"}))
 
@@ -224,13 +224,13 @@
                            :in ["request" "query-params"]})))
 
     (fact "body-params"
-      (let [[status body] (post* app "/body-params" (json {:x 1, :y 2}))]
+      (let [[status body] (post* app "/body-params" (json-string {:x 1, :y 2}))]
         status => 200
         body => {:total 3})
-      (let [[status body] (post* app "/body-params" (json {:x 1}))]
+      (let [[status body] (post* app "/body-params" (json-string {:x 1}))]
         status => 200
         body => {:total 1})
-      (let [[status body] (post* app "/body-params" (json {:x "1"}))]
+      (let [[status body] (post* app "/body-params" (json-string {:x "1"}))]
         status => 400
         body => (contains {:coercion "spec"
                            :in ["request" "body-params"]})))
@@ -255,24 +255,24 @@
                              :in ["response" "body"]})))
 
       (fact "parameters as data-specs"
-        (let [[status body] (post* app "/resource" (json {:x 1, :y 2}))]
+        (let [[status body] (post* app "/resource" (json-string {:x 1, :y 2}))]
           status => 200
           body => {:total 3})
-        (let [[status body] (post* app "/resource" (json {:x 1}))]
+        (let [[status body] (post* app "/resource" (json-string {:x 1}))]
           status => 200
           body => {:total 1})
-        (let [[status body] (post* app "/resource" (json {:x -1, :y -2}))]
+        (let [[status body] (post* app "/resource" (json-string {:x -1, :y -2}))]
           status => 500
           body => (contains {:coercion "spec"
                              :in ["response" "body"]}))))
 
     (fact "extra keys are stripped from body-params before validation"
       (fact "for resources"
-        (let [[status body] (put* app "/resource" (json {:x 1, :y 2 ::kikka "kakka"}))]
+        (let [[status body] (put* app "/resource" (json-string {:x 1, :y 2 ::kikka "kakka"}))]
           status => 200
           body => {:x 1, :y 2}))
       (fact "for endpoints"
-        (let [[status body] (put* app "/body" (json {:x 1, :y 2 ::kikka "kakka"}))]
+        (let [[status body] (put* app "/body" (json-string {:x 1, :y 2 ::kikka "kakka"}))]
           status => 200
           body => {:x 1, :y 2})))
 


### PR DESCRIPTION
Drop direct dependency to Cheshire in favour of Muuntaja, which is also injected into request for endpoints to use. Muuntaja uses Cheshire under the covers.