### PR TITLE
Correct mismatched brackets in README examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ See [CHANGELOG](https://github.com/metosin/compojure-api/blob/master/CHANGELOG.m
 ```clj
 (resource
   {:get
-   {:parameters {:query-params {:name String}
+   {:parameters {:query-params {:name String}}
     :responses {200 {:schema {:message String}}}
     :handler (fn [{{:keys [name]} :query-params}]
                (a/go
                  (a/<! (a/timeout 500))
-                 (ok {:message (str "Hello, " name)})}}})
+                 (ok {:message (str "Hello, " name)})))}})
 ```
 
 ### Hello World, async, data-driven & clojure.spec
@@ -85,12 +85,12 @@ See [CHANGELOG](https://github.com/metosin/compojure-api/blob/master/CHANGELOG.m
 (resource
   {:coercion :spec
    :get
-   {:parameters {:query-params (s/keys :req-un [::name])}}
+   {:parameters {:query-params (s/keys :req-un [::name])}
     :responses {200 {:schema (s/keys :req-un [::message])}}
     :handler (fn [{{:keys [name]} :query-params}]
                (a/go
                  (a/<! (a/timeout 500))
-                 (ok {:message (str "Hello, " name)})}}})
+                 (ok {:message (str "Hello, " name)})))}})
 ```
 
 ### Api with Schema & Swagger-docs


### PR DESCRIPTION
Minor - noticed these while pasting the examples into my editor.