### PR TITLE
Give better error message when binding isn't valid. Fixes #354

### DIFF
--- a/src/compojure/api/meta.clj
+++ b/src/compojure/api/meta.clj
@@ -26,12 +26,18 @@
   (dissoc schema 'schema.core/Keyword))
 
 (defn fnk-schema [bind]
-  (->>
-    (:input-schema
+  (try
+    (->>
+     (:input-schema
       (fnk-impl/letk-input-schema-and-body-form
-        nil (with-meta bind {:schema s/Any}) [] nil))
-    reverse
-    (into {})))
+       nil (with-meta bind {:schema s/Any}) [] nil))
+     reverse
+     (into {}))
+    (catch Exception _
+        (throw (IllegalArgumentException.
+                (str "Binding " bind " is not valid, please refer to "
+                     "https://github.com/plumatic/plumbing/tree/master/src/plumbing/fnk#fnk-syntax\n"
+                     " for more information."))))))
 
 (s/defn src-coerce!
   "Return source code for coerce! for a schema with coercion type,

--- a/test/compojure/api/integration_test.clj
+++ b/test/compojure/api/integration_test.clj
@@ -1089,7 +1089,19 @@
                   (GET "/api/ping" []
                     :name :pong
                     identity))]
-      (eval app') => (throws RuntimeException))))
+      (eval app') => (throws RuntimeException)))
+
+  (fact "bindings with wrong syntax should fail"
+    (let [app' `(api
+                 (GET "/api/:id/pong" []
+                  :path-params [id ::id]
+                  :name :pong
+                  identity))]
+      (eval app') => (throws java.lang.IllegalArgumentException
+                             (str  "Binding [compojure.api.integration-test/id :compojure.api.integration-test/id] "
+                                   "is not valid, please refer to "
+                                   "https://github.com/plumatic/plumbing/tree/master/src/plumbing/fnk#fnk-syntax")))))
+
 
 
 (fact "swagger-spec-path"


### PR DESCRIPTION
- Catch the exception thrown in `fnk-schema` and rethrow it with link
  to fnk-syntax