### PR TITLE
Change check fn? by ifn?

### DIFF
--- a/src/compojure/api/middleware.clj
+++ b/src/compojure/api/middleware.clj
@@ -54,7 +54,7 @@
                              (if (::rethrow-exceptions? request)
                                (raise e)
                                (respond (call-error-handler default-handler handlers e request))))]
-    (assert (fn? default-handler) "Default exception handler must be a function.")
+    (assert (ifn? default-handler) "Default exception handler must be a function.")
     (fn
       ([request]
        (try


### PR DESCRIPTION
Hello!

I've been having issues with this and I'm proposing you this change to see what do you think.
Checking with `fn?` returns false for data structures implementing the `IFn` interface such as keywords or more importantly, multimethods. `ifn?` solves this and checks for any data structure implementing `IFn`.

Thanks!