### PR TITLE
Deal with coercion exceptions in async handlers

### DIFF
--- a/src/compojure/api/coercion.clj
+++ b/src/compojure/api/coercion.clj
@@ -94,6 +94,8 @@
      (handler
        request
        (fn [response]
-         ;; TODO: should raise..
-         (respond (coerce-response! request response responses)))
+         (try
+           (respond (coerce-response! request response responses))
+           (catch Exception e
+             (raise e))))
        raise))))


### PR DESCRIPTION
When async handlers returned an invalid format, the previous
wrap-coerce-response would just time out instead of passing the
error.