### PR TITLE
File download needs to disable json encoding of content body

### DIFF
--- a/examples/thingie/src/examples/thingie.clj
+++ b/examples/thingie/src/examples/thingie.clj
@@ -8,6 +8,7 @@
             [examples.pizza :refer [pizza-routes Pizza]]
             [examples.ordered :refer [ordered-routes]]
             [examples.dates :refer [date-routes]]
+	    [muuntaja.core :as muuntaja]
             [clojure.java.io :as io])
   (:import (org.joda.time DateTime)
            (java.io File)))
@@ -212,7 +213,8 @@
         (-> (io/resource "screenshot.png")
             (io/input-stream)
             (ok)
-            (header "Content-Type" "image/png"))))
+            (header "Content-Type" "image/png")
+            (muuntaja/disable-response-encoding)))
 
     (context "/component" []
       :tags ["component"]

--- a/examples/thingie/src/examples/thingie.clj
+++ b/examples/thingie/src/examples/thingie.clj
@@ -214,7 +214,7 @@
             (io/input-stream)
             (ok)
             (header "Content-Type" "image/png")
-            (muuntaja/disable-response-encoding)))
+            (muuntaja/disable-response-encoding))))
 
     (context "/component" []
       :tags ["component"]

--- a/test/compojure/api/download_test.clj
+++ b/test/compojure/api/download_test.clj
@@ -1,0 +1,44 @@
+(ns compojure.api.download-test
+  (:require  [midje.sweet :as midje]
+             [compojure.api.sweet :as sw :refer [api context
+                                                 undocumented
+                                                 GET PUT POST DELETE]]
+             [midje.sweet :refer :all]
+             [ring.mock.request :as mock]
+             [clojure.java.io :as io]
+             [ring.util.http-response :refer [ok header]]
+             [muuntaja.core :as muuntaja])
+  (:import (java.io File)) )
+
+(def app
+  (api
+   {:swagger
+    {:ui "/"
+     :spec "/swagger.json"
+     :data {:info {:title "API"
+                   :description "API methods "}
+            :tags [{:name "api", :description ""}]}}}
+   
+   (context "/download" []
+            :tags ["download"]
+
+            (GET "/file" []
+                 :summary "file download"
+                 :return File
+                 :produces ["image/png"]
+                 (-> (io/resource "screenshot.png")
+                     (io/input-stream)
+                     (ok)
+                     (header "Content-Type" "image/png")
+                     (muuntaja/disable-response-encoding))))))
+
+(fact "download returns data file "
+      (let [response (app (-> (mock/request :get "/download/file")))
+            klass (-> response :body class)
+            status (:status response)]
+        status => 200
+        klass => java.io.BufferedInputStream))
+
+
+
+


### PR DESCRIPTION
In the examples/thingie/src/examples/thingie.clj, downloading a file fails as the following code

``` clojure
   (GET "/file" []
        :summary "file download"
        :return File
        :produces ["image/png"]
        (-> (io/resource "screenshot.png")
            (io/input-stream)
            (ok)
            (header "Content-Type" "image/png"))))
```
tries to json-encode the BufferedInputStream by default.

I've changed the example to add a call to ```disable-response-encoding```, and added a separate test for the same.