### PR TITLE
Remove logging that tells when coercion is enabled

### DIFF
--- a/src/compojure/api/coercion/schema.clj
+++ b/src/compojure/api/coercion/schema.clj
@@ -5,7 +5,6 @@
             [ring.swagger.coerce :as coerce]
             [compojure.api.request :as request]
             [compojure.api.coercion.core :as cc]
-            [compojure.api.impl.logging :as log]
             [clojure.walk :as walk]
             [schema.core :as s]
             [compojure.api.common :as common])
@@ -89,5 +88,3 @@
 (def default-coercion (create-coercion default-options))
 
 (defmethod cc/named-coercion :schema [_] default-coercion)
-
-(log/log! :info ":schema coercion enabled in compojure.api")

--- a/src/compojure/api/coercion/spec.clj
+++ b/src/compojure/api/coercion/spec.clj
@@ -5,7 +5,6 @@
             [spec-tools.data-spec :as ds]
             [clojure.walk :as walk]
             [compojure.api.coercion.core :as cc]
-            [compojure.api.impl.logging :as log]
             [spec-tools.transform :as stt]
             [spec-tools.swagger.core :as swagger]
             [compojure.api.common :as common])
@@ -145,5 +144,3 @@
 (def default-coercion (create-coercion default-options))
 
 (defmethod cc/named-coercion :spec [_] default-coercion)
-
-(log/log! :info ":spec coercion enabled in compojure.api")


### PR DESCRIPTION
Removes the log call that is shown every time compojure coercion is enabled.

The logging is unnecessary and unexpected because it shows every time the schema/spec coercion namespace is required.