### PR TITLE
Add `pedantic? :abort`, fix dep conflicts (#415)

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,18 +5,23 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
-  :dependencies [[potemkin "0.4.5"]
+  :dependencies [; Fix conflicts
+                 [clj-time "0.15.1"]
+                 [riddley "0.2.0"]
+
+                 [potemkin "0.4.5"]
                  [prismatic/schema "1.1.10"]
                  [prismatic/plumbing "0.5.5"]
                  [ikitommi/linked "1.3.1-alpha1"] ;; waiting for the original
                  [metosin/muuntaja "0.6.4"]
                  [com.fasterxml.jackson.datatype/jackson-datatype-joda "2.9.8"]
-                 [ring/ring-core "1.7.1" :exclusions [clj-time commons-codec]]
-                 [compojure "1.6.1" :exclusions [joda-time]]
+                 [ring/ring-core "1.7.1"]
+                 [compojure "1.6.1" ]
                  [metosin/spec-tools "0.9.1"]
-                 [metosin/ring-http-response "0.9.1" :exclusions [joda-time]]
+                 [metosin/ring-http-response "0.9.1"]
                  [metosin/ring-swagger-ui "2.2.10"]
-                 [metosin/ring-swagger "0.26.2" :exclusions [joda-time]]]
+                 [metosin/ring-swagger "0.26.2"]]
+  :pedantic? :abort
   :profiles {:uberjar {:aot :all
                        :ring {:handler examples.thingie/app}
                        :source-paths ["examples/thingie/src"]
@@ -29,10 +34,10 @@
                              [lein-ring "0.12.5"]
                              [funcool/codeina "0.5.0"]]
                    :dependencies [[org.clojure/clojure "1.10.0"]
-                                  [org.clojure/core.async "0.4.490" :exclusions [org.clojure/tools.reader]]
+                                  [org.clojure/core.async "0.4.490"]
                                   [javax.servlet/javax.servlet-api "4.0.1"]
-                                  [peridot "0.5.1" :exclusions [clj-time commons-codec]]
-                                  [midje "1.9.6" :exclusions [org.clojure/tools.namespace com.rpl/specter commons-codec clj-time]]
+                                  [peridot "0.5.1"]
+                                  [midje "1.9.6"]
                                   [com.rpl/specter "1.1.2"]
                                   [com.stuartsierra/component "0.4.0"]
                                   [expound "0.7.2"]
@@ -40,7 +45,7 @@
                                   [reloaded.repl "0.2.4"]
                                   [metosin/muuntaja-msgpack "0.6.4"]
                                   [metosin/muuntaja-yaml "0.6.4"]
-                                  [org.immutant/immutant "2.1.10" :exclusions [joda-time org.slf4j/slf4j-api]]
+                                  [org.immutant/immutant "2.1.10"]
                                   [http-kit "2.3.0"]
                                   [criterium "0.4.4"]]
                    :test-paths ["test19"]
@@ -55,7 +60,7 @@
                                       [org.slf4j/jcl-over-slf4j "1.7.26"]
                                       [org.slf4j/jul-to-slf4j "1.7.26"]
                                       [org.slf4j/log4j-over-slf4j "1.7.26"]
-                                      [ch.qos.logback/logback-classic "1.2.3" :exclusions [org.slf4j/slf4j-api]]]}
+                                      [ch.qos.logback/logback-classic "1.2.3" ]]}
              :async {:jvm-opts ["-Dcompojure-api.test.async=true"]
                      :dependencies [[manifold "0.1.8" :exclusions [org.clojure/tools.logging]]]}}
   :eastwood {:namespaces [:source-paths]


### PR DESCRIPTION
* Added `:pendatic? :abort`.
* Revised conflict resolution: instead of using `:exclusions` I explicitly "pinned" libs causing conflicts at the very top of the deps list in the new section `; Fix conflicts`.
* Couldn't delete exclusions from `[manifold "0.1.8" :exclusions [org.clojure/tools.logging]]` because then tests fail in peculiar way:

<details>
        <summary>Click to expand</summary>

```
ᐅ lein do clean, all midje
Tried to load commons-io version 2.5 but 2.6 was already loaded.
Tried to load com.google.guava/guava version 19.0 but 20.0 was already loaded.
Performing task 'midje' with profile(s): 'dev'
WARNING: any? already refers to: #'clojure.core/any? in namespace: leiningen.midje, being replaced by: #'leiningen.midje/any?
WARN clojure.tools.logging not found on classpath, compojure.api logging to console.
Warning: Nashorn engine is planned to be removed from a future JDK release
nil
All checks (656) succeeded.
Performing task 'midje' with profile(s): 'dev,async'
Warning: Nashorn engine is planned to be removed from a future JDK release
LOAD FAILURE for compojure.api.routes-test
clojure.lang.Compiler$CompilerException: Syntax error compiling at (compojure/api/routes_test.clj:167:1).
    data: #:clojure.error{:phase :compile-syntax-check,
                          :line 167,
                          :column 1,
                          :source "compojure/api/routes_test.clj"}
             java.lang.RuntimeException: Can't take value of a macro: #'compojure.api.impl.logging/log!
                        ...                 
       clojure.core/load/fn   core.clj: 6126
          clojure.core/load   core.clj: 6125
          clojure.core/load   core.clj: 6109
                        ...                 
      clojure.core/load-one   core.clj: 5908
   clojure.core/load-lib/fn   core.clj: 5948
      clojure.core/load-lib   core.clj: 5947
      clojure.core/load-lib   core.clj: 5928
                        ...                 
         clojure.core/apply   core.clj:  667
     clojure.core/load-libs   core.clj: 5985
     clojure.core/load-libs   core.clj: 5969
                        ...                 
         clojure.core/apply   core.clj:  667
       clojure.core/require   core.clj: 6007 (repeats 2 times)
                        ...                 
midje.repl/load-facts/fn/fn   repl.clj:  208
   midje.repl/load-facts/fn   repl.clj:  208
      midje.repl/load-facts   repl.clj:  194 (repeats 2 times)
                        ...                 
             user/eval11342  REPL Input     
                        ...                 
   clojure.main/load-script   main.clj:  452
      clojure.main/init-opt   main.clj:  454
    clojure.main/initialize   main.clj:  485
      clojure.main/null-opt   main.clj:  519
          clojure.main/main   main.clj:  598
          clojure.main/main   main.clj:  561
                        ...                 
          clojure.main.main  main.java:   37

LOAD FAILURE for compojure.api.integration-test
clojure.lang.Compiler$CompilerException: Syntax error compiling at (compojure/api/integration_test.clj:1294:1).
    data: #:clojure.error{:phase :compile-syntax-check,
                          :line 1294,
                          :column 1,
                          :source "compojure/api/integration_test.clj"}
             java.lang.RuntimeException: Can't take value of a macro: #'compojure.api.impl.logging/log!
                        ...                 
       clojure.core/load/fn   core.clj: 6126
          clojure.core/load   core.clj: 6125
          clojure.core/load   core.clj: 6109
                        ...                 
      clojure.core/load-one   core.clj: 5908
   clojure.core/load-lib/fn   core.clj: 5948
      clojure.core/load-lib   core.clj: 5947
      clojure.core/load-lib   core.clj: 5928
                        ...                 
         clojure.core/apply   core.clj:  667
     clojure.core/load-libs   core.clj: 5985
     clojure.core/load-libs   core.clj: 5969
                        ...                 
         clojure.core/apply   core.clj:  667
       clojure.core/require   core.clj: 6007 (repeats 2 times)
                        ...                 
midje.repl/load-facts/fn/fn   repl.clj:  208
   midje.repl/load-facts/fn   repl.clj:  208
      midje.repl/load-facts   repl.clj:  194 (repeats 2 times)
                        ...                 
             user/eval11342  REPL Input     
                        ...                 
   clojure.main/load-script   main.clj:  452
      clojure.main/init-opt   main.clj:  454
    clojure.main/initialize   main.clj:  485
      clojure.main/null-opt   main.clj:  519
          clojure.main/main   main.clj:  598
          clojure.main/main   main.clj:  561
                        ...                 
          clojure.main.main  main.java:   37

02:03:55.006 [main] ERROR compojure.api.exception - kosh
java.lang.RuntimeException: kosh
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41635$fn__41636.invoke(middleware_test.clj:53) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41635.invoke(middleware_test.clj:53) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634.invoke(middleware_test.clj:53) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invokeStatic(thread_safe_var_nesting.clj:32) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invoke(thread_safe_var_nesting.clj:30) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633.invoke(middleware_test.clj:53) ~[na:na]
	at clojure.lang.AFn.applyToHelper(AFn.java:152) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFunction$1.doInvoke(AFunction.java:31) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.0.jar:na]
	at midje.checking.facts$check_one$fn__3632.invoke(facts.clj:32) ~[na:na]
	at midje.checking.facts$check_one.invokeStatic(facts.clj:31) ~[na:na]
	at midje.checking.facts$check_one.invoke(facts.clj:9) ~[na:na]
	at midje.checking.facts$creation_time_check.invokeStatic(facts.clj:36) ~[na:na]
	at midje.checking.facts$creation_time_check.invoke(facts.clj:34) ~[na:na]
	at compojure.api.middleware_test$eval41632.invokeStatic(middleware_test.clj:53) ~[na:na]
	at compojure.api.middleware_test$eval41632.invoke(middleware_test.clj:53) ~[na:na]
	at clojure.lang.Compiler.eval(Compiler.java:7176) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.load(Compiler.java:7635) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.loadResourceScript(RT.java:381) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.loadResourceScript(RT.java:372) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.load(RT.java:463) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.load(RT.java:428) ~[clojure-1.10.0.jar:na]
	at clojure.core$load$fn__6824.invoke(core.clj:6126) ~[clojure-1.10.0.jar:na]
	at clojure.core$load.invokeStatic(core.clj:6125) ~[clojure-1.10.0.jar:na]
	at clojure.core$load.doInvoke(core.clj:6109) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:408) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_one.invokeStatic(core.clj:5908) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_one.invoke(core.clj:5903) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_lib$fn__6765.invoke(core.clj:5948) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_lib.invokeStatic(core.clj:5947) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_lib.doInvoke(core.clj:5928) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:142) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:667) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_libs.invokeStatic(core.clj:5985) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_libs.doInvoke(core.clj:5969) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:137) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:667) ~[clojure-1.10.0.jar:na]
	at clojure.core$require.invokeStatic(core.clj:6007) ~[clojure-1.10.0.jar:na]
	at clojure.core$require.doInvoke(core.clj:6007) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:421) ~[clojure-1.10.0.jar:na]
	at midje.repl$load_facts$fn__11275$fn__11280.invoke(repl.clj:208) ~[na:na]
	at midje.repl$load_facts$fn__11275.invoke(repl.clj:208) ~[na:na]
	at midje.repl$load_facts.invokeStatic(repl.clj:194) ~[na:na]
	at midje.repl$load_facts.doInvoke(repl.clj:194) ~[na:na]
	at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.0.jar:na]
	at user$eval11342.invokeStatic(form-init6402394038491610389.clj:1) ~[na:na]
	at user$eval11342.invoke(form-init6402394038491610389.clj:1) ~[na:na]
	at clojure.lang.Compiler.eval(Compiler.java:7176) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.eval(Compiler.java:7166) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.load(Compiler.java:7635) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.loadFile(Compiler.java:7573) ~[clojure-1.10.0.jar:na]
	at clojure.main$load_script.invokeStatic(main.clj:452) ~[clojure-1.10.0.jar:na]
	at clojure.main$init_opt.invokeStatic(main.clj:454) ~[clojure-1.10.0.jar:na]
	at clojure.main$init_opt.invoke(main.clj:454) ~[clojure-1.10.0.jar:na]
	at clojure.main$initialize.invokeStatic(main.clj:485) ~[clojure-1.10.0.jar:na]
	at clojure.main$null_opt.invokeStatic(main.clj:519) ~[clojure-1.10.0.jar:na]
	at clojure.main$null_opt.invoke(main.clj:516) ~[clojure-1.10.0.jar:na]
	at clojure.main$main.invokeStatic(main.clj:598) ~[clojure-1.10.0.jar:na]
	at clojure.main$main.doInvoke(main.clj:561) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:137) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Var.applyTo(Var.java:705) ~[clojure-1.10.0.jar:na]
	at clojure.main.main(main.java:37) ~[clojure-1.10.0.jar:na]
02:03:55.013 [main] ERROR compojure.api.exception - kosh
java.lang.RuntimeException: kosh
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41635$fn__41636.invoke(middleware_test.clj:53) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41635.invoke(middleware_test.clj:53) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634.invoke(middleware_test.clj:53) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invokeStatic(thread_safe_var_nesting.clj:32) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invoke(thread_safe_var_nesting.clj:30) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633.invoke(middleware_test.clj:53) ~[na:na]
	at clojure.lang.AFn.applyToHelper(AFn.java:152) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFunction$1.doInvoke(AFunction.java:31) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.0.jar:na]
	at midje.checking.facts$check_one$fn__3632.invoke(facts.clj:32) ~[na:na]
	at midje.checking.facts$check_one.invokeStatic(facts.clj:31) ~[na:na]
	at midje.checking.facts$check_one.invoke(facts.clj:9) ~[na:na]
	at midje.checking.facts$creation_time_check.invokeStatic(facts.clj:36) ~[na:na]
	at midje.checking.facts$creation_time_check.invoke(facts.clj:34) ~[na:na]
	at compojure.api.middleware_test$eval41632.invokeStatic(middleware_test.clj:53) ~[na:na]
	at compojure.api.middleware_test$eval41632.invoke(middleware_test.clj:53) ~[na:na]
	at clojure.lang.Compiler.eval(Compiler.java:7176) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.load(Compiler.java:7635) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.loadResourceScript(RT.java:381) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.loadResourceScript(RT.java:372) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.load(RT.java:463) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.load(RT.java:428) ~[clojure-1.10.0.jar:na]
	at clojure.core$load$fn__6824.invoke(core.clj:6126) ~[clojure-1.10.0.jar:na]
	at clojure.core$load.invokeStatic(core.clj:6125) ~[clojure-1.10.0.jar:na]
	at clojure.core$load.doInvoke(core.clj:6109) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:408) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_one.invokeStatic(core.clj:5908) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_one.invoke(core.clj:5903) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_lib$fn__6765.invoke(core.clj:5948) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_lib.invokeStatic(core.clj:5947) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_lib.doInvoke(core.clj:5928) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:142) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:667) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_libs.invokeStatic(core.clj:5985) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_libs.doInvoke(core.clj:5969) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:137) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:667) ~[clojure-1.10.0.jar:na]
	at clojure.core$require.invokeStatic(core.clj:6007) ~[clojure-1.10.0.jar:na]
	at clojure.core$require.doInvoke(core.clj:6007) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:421) ~[clojure-1.10.0.jar:na]
	at midje.repl$load_facts$fn__11275$fn__11280.invoke(repl.clj:208) ~[na:na]
	at midje.repl$load_facts$fn__11275.invoke(repl.clj:208) ~[na:na]
	at midje.repl$load_facts.invokeStatic(repl.clj:194) ~[na:na]
	at midje.repl$load_facts.doInvoke(repl.clj:194) ~[na:na]
	at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.0.jar:na]
	at user$eval11342.invokeStatic(form-init6402394038491610389.clj:1) ~[na:na]
	at user$eval11342.invoke(form-init6402394038491610389.clj:1) ~[na:na]
	at clojure.lang.Compiler.eval(Compiler.java:7176) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.eval(Compiler.java:7166) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.load(Compiler.java:7635) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.loadFile(Compiler.java:7573) ~[clojure-1.10.0.jar:na]
	at clojure.main$load_script.invokeStatic(main.clj:452) ~[clojure-1.10.0.jar:na]
	at clojure.main$init_opt.invokeStatic(main.clj:454) ~[clojure-1.10.0.jar:na]
	at clojure.main$init_opt.invoke(main.clj:454) ~[clojure-1.10.0.jar:na]
	at clojure.main$initialize.invokeStatic(main.clj:485) ~[clojure-1.10.0.jar:na]
	at clojure.main$null_opt.invokeStatic(main.clj:519) ~[clojure-1.10.0.jar:na]
	at clojure.main$null_opt.invoke(main.clj:516) ~[clojure-1.10.0.jar:na]
	at clojure.main$main.invokeStatic(main.clj:598) ~[clojure-1.10.0.jar:na]
	at clojure.main$main.doInvoke(main.clj:561) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:137) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Var.applyTo(Var.java:705) ~[clojure-1.10.0.jar:na]
	at clojure.main.main(main.java:37) ~[clojure-1.10.0.jar:na]
02:03:55.022 [main] ERROR compojure.api.exception - kosh
java.lang.RuntimeException: kosh
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41669$fn__41670$fn__41671$fn__41672.invoke(middleware_test.clj:53) ~[na:na]
	at compojure.api.middleware$wrap_exceptions$fn__21682.invoke(middleware.clj:62) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41669$fn__41670$fn__41671$fn__41674.invoke(middleware_test.clj:83) ~[na:na]
	at midje.checking.checkables$check_one$fn__10577$fn__10578.invoke(checkables.clj:125) ~[na:na]
	at midje.checking.checkables$check_one$fn__10577.invoke(checkables.clj:124) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invokeStatic(thread_safe_var_nesting.clj:32) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invoke(thread_safe_var_nesting.clj:30) ~[na:na]
	at midje.checking.checkables$check_one.invokeStatic(checkables.clj:122) ~[na:na]
	at midje.checking.checkables$check_one.invoke(checkables.clj:116) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41669$fn__41670$fn__41671.invoke(middleware_test.clj:53) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invokeStatic(thread_safe_var_nesting.clj:32) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invoke(thread_safe_var_nesting.clj:30) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41669$fn__41670.invoke(middleware_test.clj:53) ~[na:na]
	at clojure.lang.AFn.applyToHelper(AFn.java:152) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFunction$1.doInvoke(AFunction.java:31) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.0.jar:na]
	at midje.checking.facts$check_one$fn__3628.invoke(facts.clj:15) ~[na:na]
	at midje.checking.facts$check_one.invokeStatic(facts.clj:14) ~[na:na]
	at midje.checking.facts$check_one.invoke(facts.clj:9) ~[na:na]
	at midje.checking.facts$creation_time_check.invokeStatic(facts.clj:36) ~[na:na]
	at midje.checking.facts$creation_time_check.invoke(facts.clj:34) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41669.invoke(middleware_test.clj:53) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634.invoke(middleware_test.clj:53) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invokeStatic(thread_safe_var_nesting.clj:32) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invoke(thread_safe_var_nesting.clj:30) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633.invoke(middleware_test.clj:53) ~[na:na]
	at clojure.lang.AFn.applyToHelper(AFn.java:152) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFunction$1.doInvoke(AFunction.java:31) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.0.jar:na]
	at midje.checking.facts$check_one$fn__3632.invoke(facts.clj:32) ~[na:na]
	at midje.checking.facts$check_one.invokeStatic(facts.clj:31) ~[na:na]
	at midje.checking.facts$check_one.invoke(facts.clj:9) ~[na:na]
	at midje.checking.facts$creation_time_check.invokeStatic(facts.clj:36) ~[na:na]
	at midje.checking.facts$creation_time_check.invoke(facts.clj:34) ~[na:na]
	at compojure.api.middleware_test$eval41632.invokeStatic(middleware_test.clj:53) ~[na:na]
	at compojure.api.middleware_test$eval41632.invoke(middleware_test.clj:53) ~[na:na]
	at clojure.lang.Compiler.eval(Compiler.java:7176) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.load(Compiler.java:7635) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.loadResourceScript(RT.java:381) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.loadResourceScript(RT.java:372) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.load(RT.java:463) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.load(RT.java:428) ~[clojure-1.10.0.jar:na]
	at clojure.core$load$fn__6824.invoke(core.clj:6126) ~[clojure-1.10.0.jar:na]
	at clojure.core$load.invokeStatic(core.clj:6125) ~[clojure-1.10.0.jar:na]
	at clojure.core$load.doInvoke(core.clj:6109) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:408) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_one.invokeStatic(core.clj:5908) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_one.invoke(core.clj:5903) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_lib$fn__6765.invoke(core.clj:5948) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_lib.invokeStatic(core.clj:5947) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_lib.doInvoke(core.clj:5928) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:142) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:667) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_libs.invokeStatic(core.clj:5985) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_libs.doInvoke(core.clj:5969) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:137) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:667) ~[clojure-1.10.0.jar:na]
	at clojure.core$require.invokeStatic(core.clj:6007) ~[clojure-1.10.0.jar:na]
	at clojure.core$require.doInvoke(core.clj:6007) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:421) ~[clojure-1.10.0.jar:na]
	at midje.repl$load_facts$fn__11275$fn__11280.invoke(repl.clj:208) ~[na:na]
	at midje.repl$load_facts$fn__11275.invoke(repl.clj:208) ~[na:na]
	at midje.repl$load_facts.invokeStatic(repl.clj:194) ~[na:na]
	at midje.repl$load_facts.doInvoke(repl.clj:194) ~[na:na]
	at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.0.jar:na]
	at user$eval11342.invokeStatic(form-init6402394038491610389.clj:1) ~[na:na]
	at user$eval11342.invoke(form-init6402394038491610389.clj:1) ~[na:na]
	at clojure.lang.Compiler.eval(Compiler.java:7176) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.eval(Compiler.java:7166) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.load(Compiler.java:7635) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.loadFile(Compiler.java:7573) ~[clojure-1.10.0.jar:na]
	at clojure.main$load_script.invokeStatic(main.clj:452) ~[clojure-1.10.0.jar:na]
	at clojure.main$init_opt.invokeStatic(main.clj:454) ~[clojure-1.10.0.jar:na]
	at clojure.main$init_opt.invoke(main.clj:454) ~[clojure-1.10.0.jar:na]
	at clojure.main$initialize.invokeStatic(main.clj:485) ~[clojure-1.10.0.jar:na]
	at clojure.main$null_opt.invokeStatic(main.clj:519) ~[clojure-1.10.0.jar:na]
	at clojure.main$null_opt.invoke(main.clj:516) ~[clojure-1.10.0.jar:na]
	at clojure.main$main.invokeStatic(main.clj:598) ~[clojure-1.10.0.jar:na]
	at clojure.main$main.doInvoke(main.clj:561) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:137) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Var.applyTo(Var.java:705) ~[clojure-1.10.0.jar:na]
	at clojure.main.main(main.java:37) ~[clojure-1.10.0.jar:na]

FAIL wrap-exceptions - Default handler logs exceptions to console at (middleware_test.clj:83)
Expected:
"ERROR kosh\n"
Actual:
""
Diffs: strings have 1 difference (0% similarity)
                expected: "(ERROR kosh\n)"
                actual:   "(-----------)"
02:03:55.052 [main] INFO  compojure.api.exception - Error parsing request
clojure.lang.ExceptionInfo: Error parsing request
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41691$fn__41692$fn__41693.invoke(middleware_test.clj:53) ~[na:na]
	at compojure.api.middleware$wrap_exceptions$fn__21682.invoke(middleware.clj:62) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41691$fn__41692$fn__41695.invoke(middleware_test.clj:95) ~[na:na]
	at midje.checking.checkables$check_one$fn__10577$fn__10578.invoke(checkables.clj:125) ~[na:na]
	at midje.checking.checkables$check_one$fn__10577.invoke(checkables.clj:124) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invokeStatic(thread_safe_var_nesting.clj:32) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invoke(thread_safe_var_nesting.clj:30) ~[na:na]
	at midje.checking.checkables$check_one.invokeStatic(checkables.clj:122) ~[na:na]
	at midje.checking.checkables$check_one.invoke(checkables.clj:116) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41691$fn__41692.invoke(middleware_test.clj:53) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invokeStatic(thread_safe_var_nesting.clj:32) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invoke(thread_safe_var_nesting.clj:30) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634$fn__41691.invoke(middleware_test.clj:53) ~[na:na]
	at clojure.lang.AFn.applyToHelper(AFn.java:152) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFunction$1.doInvoke(AFunction.java:31) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.0.jar:na]
	at midje.checking.facts$check_one$fn__3628.invoke(facts.clj:15) ~[na:na]
	at midje.checking.facts$check_one.invokeStatic(facts.clj:14) ~[na:na]
	at midje.checking.facts$check_one.invoke(facts.clj:9) ~[na:na]
	at midje.checking.facts$creation_time_check.invokeStatic(facts.clj:36) ~[na:na]
	at midje.checking.facts$creation_time_check.invoke(facts.clj:34) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633$fn__41634.invoke(middleware_test.clj:53) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invokeStatic(thread_safe_var_nesting.clj:32) ~[na:na]
	at midje.util.thread_safe_var_nesting$with_altered_roots_STAR_.invoke(thread_safe_var_nesting.clj:30) ~[na:na]
	at compojure.api.middleware_test$eval41632$fn__41633.invoke(middleware_test.clj:53) ~[na:na]
	at clojure.lang.AFn.applyToHelper(AFn.java:152) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFn.applyTo(AFn.java:144) ~[clojure-1.10.0.jar:na]
	at clojure.lang.AFunction$1.doInvoke(AFunction.java:31) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.0.jar:na]
	at midje.checking.facts$check_one$fn__3632.invoke(facts.clj:32) ~[na:na]
	at midje.checking.facts$check_one.invokeStatic(facts.clj:31) ~[na:na]
	at midje.checking.facts$check_one.invoke(facts.clj:9) ~[na:na]
	at midje.checking.facts$creation_time_check.invokeStatic(facts.clj:36) ~[na:na]
	at midje.checking.facts$creation_time_check.invoke(facts.clj:34) ~[na:na]
	at compojure.api.middleware_test$eval41632.invokeStatic(middleware_test.clj:53) ~[na:na]
	at compojure.api.middleware_test$eval41632.invoke(middleware_test.clj:53) ~[na:na]
	at clojure.lang.Compiler.eval(Compiler.java:7176) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.load(Compiler.java:7635) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.loadResourceScript(RT.java:381) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.loadResourceScript(RT.java:372) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.load(RT.java:463) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RT.load(RT.java:428) ~[clojure-1.10.0.jar:na]
	at clojure.core$load$fn__6824.invoke(core.clj:6126) ~[clojure-1.10.0.jar:na]
	at clojure.core$load.invokeStatic(core.clj:6125) ~[clojure-1.10.0.jar:na]
	at clojure.core$load.doInvoke(core.clj:6109) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:408) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_one.invokeStatic(core.clj:5908) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_one.invoke(core.clj:5903) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_lib$fn__6765.invoke(core.clj:5948) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_lib.invokeStatic(core.clj:5947) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_lib.doInvoke(core.clj:5928) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:142) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:667) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_libs.invokeStatic(core.clj:5985) ~[clojure-1.10.0.jar:na]
	at clojure.core$load_libs.doInvoke(core.clj:5969) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:137) ~[clojure-1.10.0.jar:na]
	at clojure.core$apply.invokeStatic(core.clj:667) ~[clojure-1.10.0.jar:na]
	at clojure.core$require.invokeStatic(core.clj:6007) ~[clojure-1.10.0.jar:na]
	at clojure.core$require.doInvoke(core.clj:6007) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.invoke(RestFn.java:421) ~[clojure-1.10.0.jar:na]
	at midje.repl$load_facts$fn__11275$fn__11280.invoke(repl.clj:208) ~[na:na]
	at midje.repl$load_facts$fn__11275.invoke(repl.clj:208) ~[na:na]
	at midje.repl$load_facts.invokeStatic(repl.clj:194) ~[na:na]
	at midje.repl$load_facts.doInvoke(repl.clj:194) ~[na:na]
	at clojure.lang.RestFn.invoke(RestFn.java:397) ~[clojure-1.10.0.jar:na]
	at user$eval11342.invokeStatic(form-init6402394038491610389.clj:1) ~[na:na]
	at user$eval11342.invoke(form-init6402394038491610389.clj:1) ~[na:na]
	at clojure.lang.Compiler.eval(Compiler.java:7176) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.eval(Compiler.java:7166) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.load(Compiler.java:7635) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Compiler.loadFile(Compiler.java:7573) ~[clojure-1.10.0.jar:na]
	at clojure.main$load_script.invokeStatic(main.clj:452) ~[clojure-1.10.0.jar:na]
	at clojure.main$init_opt.invokeStatic(main.clj:454) ~[clojure-1.10.0.jar:na]
	at clojure.main$init_opt.invoke(main.clj:454) ~[clojure-1.10.0.jar:na]
	at clojure.main$initialize.invokeStatic(main.clj:485) ~[clojure-1.10.0.jar:na]
	at clojure.main$null_opt.invokeStatic(main.clj:519) ~[clojure-1.10.0.jar:na]
	at clojure.main$null_opt.invoke(main.clj:516) ~[clojure-1.10.0.jar:na]
	at clojure.main$main.invokeStatic(main.clj:598) ~[clojure-1.10.0.jar:na]
	at clojure.main$main.doInvoke(main.clj:561) ~[clojure-1.10.0.jar:na]
	at clojure.lang.RestFn.applyTo(RestFn.java:137) ~[clojure-1.10.0.jar:na]
	at clojure.lang.Var.applyTo(Var.java:705) ~[clojure-1.10.0.jar:na]
	at clojure.main.main(main.java:37) ~[clojure-1.10.0.jar:na]
Caused by: java.lang.RuntimeException: Kosh
	... 83 common frames omitted

FAIL wrap-exceptions - Logging can be added to a exception handler at (middleware_test.clj:95)
Expected:
"INFO Error parsing request\n"
Actual:
""
Diffs: strings have 1 difference (0% similarity)
                expected: "(INFO Error parsing request\n)"
                actual:   "(---------------------------)"
Exception in thread "main" Syntax error compiling at (/private/var/folders/7_/mhk7y9952n972b6kgt7_8l700000gn/T/form-init6402394038491610389.clj:1:125).
	at clojure.lang.Compiler.load(Compiler.java:7647)
	at clojure.lang.Compiler.loadFile(Compiler.java:7573)
	at clojure.main$load_script.invokeStatic(main.clj:452)
	at clojure.main$init_opt.invokeStatic(main.clj:454)
	at clojure.main$init_opt.invoke(main.clj:454)
	at clojure.main$initialize.invokeStatic(main.clj:485)
	at clojure.main$null_opt.invokeStatic(main.clj:519)
	at clojure.main$null_opt.invoke(main.clj:516)
	at clojure.main$main.invokeStatic(main.clj:598)
	at clojure.main$main.doInvoke(main.clj:561)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.lang.Var.applyTo(Var.java:705)
	at clojure.main.main(main.java:37)
Caused by: java.lang.Exception: No namespace: compojure.api.routes-test found
	at clojure.core$the_ns.invokeStatic(core.clj:4162)
	at clojure.test$test_ns.invokeStatic(test.clj:743)
	at clojure.test$test_ns.invoke(test.clj:743)
	at clojure.core$map$fn__5851.invoke(core.clj:2753)
	at clojure.lang.LazySeq.sval(LazySeq.java:42)
	at clojure.lang.LazySeq.seq(LazySeq.java:51)
	at clojure.lang.Cons.next(Cons.java:39)
	at clojure.lang.RT.boundedLength(RT.java:1788)
	at clojure.lang.RestFn.applyTo(RestFn.java:130)
	at clojure.core$apply.invokeStatic(core.clj:667)
	at clojure.test$run_tests.invokeStatic(test.clj:768)
	at clojure.test$run_tests.doInvoke(test.clj:768)
	at clojure.lang.RestFn.applyTo(RestFn.java:137)
	at clojure.core$apply.invokeStatic(core.clj:665)
	at clojure.core$apply.invoke(core.clj:660)
	at midje.emission.clojure_test_facade$run_tests.invokeStatic(clojure_test_facade.clj:31)
	at midje.emission.clojure_test_facade$run_tests.invoke(clojure_test_facade.clj:19)
	at midje.repl$load_facts$fn__11275.invoke(repl.clj:197)
	at midje.repl$load_facts.invokeStatic(repl.clj:194)
	at midje.repl$load_facts.doInvoke(repl.clj:194)
	at clojure.lang.RestFn.invoke(RestFn.java:397)
	at user$eval11342.invokeStatic(form-init6402394038491610389.clj:1)
	at user$eval11342.invoke(form-init6402394038491610389.clj:1)
	at clojure.lang.Compiler.eval(Compiler.java:7176)
	at clojure.lang.Compiler.eval(Compiler.java:7166)
	at clojure.lang.Compiler.load(Compiler.java:7635)
	... 12 more
Error encountered performing task 'midje' with profile(s): 'dev,async'
Subprocess failed
```
</details>