### PR TITLE
update version because problens in clj-commons/ordered

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
                  [prismatic/schema "1.1.6"]
                  [org.tobereplaced/lettercase "1.0.0"]
                  [frankiesardo/linked "1.2.9"]
-                 [ring-middleware-format "0.7.2"]
+                 [ring-middleware-format "0.7.4"]
                  [metosin/ring-http-response "0.9.0"]
                  [metosin/ring-swagger "0.24.1"]
                  [metosin/ring-swagger-ui "2.2.8"]]


### PR DESCRIPTION
This lib:  [(https://github.com/clj-commons/ordered)] has undergone changes, causando alguns problemas em outras bibliotecas que dependiam delas como a clj-yaml. The lib of clj-yml is used in ring-middleware-format. All have already been updated.  Only this version of compojure-api not yet. This change addresses this issue.