### PR TITLE
1.1.x: Dependency maintenance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,8 @@ sudo: false
 language: clojure
 script: lein do clean, all midje, all check
 jdk:
-  - openjdk6
-  - openjdk7
-  - oraclejdk8
+  - openjdk8
+  - openjdk13
 cache:
   directories:
   - $HOME/.m2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* **BREAKING**: Drop support for Java 6, Java 7.
+* Update dependencies to work with more modern versions of Java.
+
 ## 1.1.12 (27.2.2018)
 
 Maintenance release, adding several patches from 2.0 branch.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 * **BREAKING**: Drop support for Java 6, Java 7.
-* Update dependencies to work with more modern versions of Java.
+* Support Java 13.
 
 ## 1.1.12 (27.2.2018)
 

--- a/project.clj
+++ b/project.clj
@@ -1,28 +1,30 @@
-(defproject metosin/compojure-api "1.1.12"
+(defproject metosin/compojure-api "1.1.13-SNAPSHOT"
   :description "Compojure Api"
   :url "https://github.com/metosin/compojure-api"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo
             :comments "same as Clojure"}
-  :dependencies [[prismatic/plumbing "0.5.4"]
-                 [potemkin "0.4.3"]
-                 [cheshire "5.6.3"]
-                 [compojure "1.6.0"]
-                 [prismatic/schema "1.1.6"]
+  :scm {:name "git"
+        :url "https://github.com/metosin/compojure-api"}
+  :dependencies [[prismatic/plumbing "0.5.5"]
+                 [potemkin "0.4.5"]
+                 [cheshire "5.9.0"]
+                 [compojure "1.6.1"]
+                 [prismatic/schema "1.1.12"]
                  [org.tobereplaced/lettercase "1.0.0"]
-                 [frankiesardo/linked "1.2.9"]
+                 [frankiesardo/linked "1.3.0"]
                  [ring-middleware-format "0.7.4"]
-                 [metosin/ring-http-response "0.9.0"]
-                 [metosin/ring-swagger "0.24.1"]
-                 [metosin/ring-swagger-ui "2.2.8"]]
+                 [metosin/ring-http-response "0.9.1"]
+                 [metosin/ring-swagger "0.26.2"]
+                 [metosin/ring-swagger-ui "2.2.10"]]
   :profiles {:uberjar {:aot :all
                        :ring {:handler examples.thingie/app}
                        :source-paths ["examples/thingie/src"]
                        :dependencies [[org.clojure/clojure "1.8.0"]
-                                      [http-kit "2.2.0"]
-                                      [reloaded.repl "0.2.3"]
-                                      [com.stuartsierra/component "0.3.2"]]}
+                                      [http-kit "2.3.0"]
+                                      [reloaded.repl "0.2.4"]
+                                      [com.stuartsierra/component "0.4.0"]]}
              :dev {:repl-options {:init-ns user}
                    :plugins [[lein-clojars "0.9.1"]
                              [lein-midje "3.2.1"]
@@ -30,15 +32,13 @@
                              [funcool/codeina "0.5.0"]]
                    :dependencies [[org.clojure/clojure "1.8.0"]
                                   [slingshot "0.12.2"]
-                                  [peridot "0.4.4"]
+                                  [peridot "0.5.1"]
                                   [javax.servlet/servlet-api "2.5"]
-                                  [midje "1.8.3"]
-                                  [com.stuartsierra/component "0.3.2"]
-                                  [reloaded.repl "0.2.3"]
-                                  [http-kit "2.2.0"]
-                                  [criterium "0.4.4"]
-                                  ; Required when using with Java 1.6
-                                  [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]]
+                                  [midje "1.9.9"]
+                                  [com.stuartsierra/component "0.4.0"]
+                                  [reloaded.repl "0.2.4"]
+                                  [http-kit "2.3.0"]
+                                  [criterium "0.4.5"]]
                    :ring {:handler examples.thingie/app
                           :reload-paths ["src" "examples/thingie/src"]}
                    :source-paths ["examples/thingie/src" "examples/thingie/dev-src"]
@@ -46,8 +46,10 @@
              :perf {:jvm-opts ^:replace ["-server"
                                          "-Xmx4096m"
                                          "-Dclojure.compiler.direct-linking=true"]}
-             :logging {:dependencies [[org.clojure/tools.logging "0.4.0"]]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}}
+             :logging {:dependencies [[org.clojure/tools.logging "0.5.0"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.1"]]}}
   :eastwood {:namespaces [:source-paths]
              :add-linters [:unused-namespaces]}
   :codeina {:sources ["src"]
@@ -55,7 +57,7 @@
             :src-uri "http://github.com/metosin/compojure-api/blob/master/"
             :src-uri-prefix "#L"}
   :deploy-repositories [["releases" :clojars]]
-  :aliases {"all" ["with-profile" "dev:dev,logging:dev,1.7"]
+  :aliases {"all" ["with-profile" "dev:dev,logging:dev,1.10"]
             "start-thingie" ["run"]
             "aot-uberjar" ["with-profile" "uberjar" "do" "clean," "ring" "uberjar"]
             "test-ancient" ["midje"]


### PR DESCRIPTION
I'm going to create a maintenance release in the 1.1.x series with the aim of supporting new versions of Java.