### PR TITLE
Fix empty spec response coercion to mirror schema

### DIFF
--- a/src/compojure/api/coercion.clj
+++ b/src/compojure/api/coercion.clj
@@ -24,8 +24,8 @@
     (satisfies? cc/Coercion coercion) coercion
     :else (throw (ex-info (str "invalid coercion " coercion) {:coercion coercion}))))
 
-(defn get-apidocs [mayby-coercion spec info]
-  (if-let [coercion (resolve-coercion mayby-coercion)]
+(defn get-apidocs [maybe-coercion spec info]
+  (if-let [coercion (resolve-coercion maybe-coercion)]
     (cc/get-apidocs coercion spec info)))
 
 (defn coerce-request! [model in type keywordize? open? request]

--- a/src/compojure/api/coercion/spec.clj
+++ b/src/compojure/api/coercion/spec.clj
@@ -101,7 +101,7 @@
                         (into
                           (empty responses)
                           (for [[k response] responses]
-                            [k (update response :schema maybe-memoized-specify)])))))
+                            [k (update response :schema #(some-> % maybe-memoized-specify))])))))
 
   (make-open [_ spec] spec)
 


### PR DESCRIPTION
Schema coercion allows `:responses {200 {}}` but spec coercion doesn't. This patch changes spec coercion to allow it as well.

Fixes #413.