### PR TITLE
prevent error caused by trying to confrom value that has already been…

### DIFF
--- a/src/compojure/api/coercion/spec.clj
+++ b/src/compojure/api/coercion/spec.clj
@@ -119,7 +119,7 @@
         (let [coerced (st/coerce spec value transformer)]
           (if (s/valid? spec coerced)
             coerced
-            (let [conformed (st/conform spec coerced transformer)]
+            (let [conformed (st/conform spec value transformer)]
               (if (s/invalid? conformed)
                 (let [problems (st/explain-data spec coerced transformer)]
                   (cc/map->CoercionError


### PR DESCRIPTION
… coerced


in my situation, i am using a spec like this to transform the parameter:
```
(def get-events-spec
  (st/spec
    {:spec (s/coll-of string?)
     :description "comma separated list of user-ids"
     :json-schema/type {:type "string"}
     :json-schema/example "1,2,3"
     :decode/string #(cs/split %2 #",")
     :encode/string #(cs/join %2 ",")}))
```
referenced like this
```
(GET "/events" []
      :coercion :spec
      :query-params [user-ids :- get-events-spec,
                                  max-age :- ::corespec/max-age ]
...
)
```
When invoked with GET /events?user-ids=1  (i.e. with missing max-age param), I get a class cast exception thrown from `cs/split`. 
This happens because the old code was calling `conform` on result of `st/coerce`, which means that the string has already been coerced into a vector of strings.
